### PR TITLE
[CP-18172][CP-18173] use single variable for secret generation, better error messages

### DIFF
--- a/charts/cloudzero-agent/README.md
+++ b/charts/cloudzero-agent/README.md
@@ -30,7 +30,7 @@ The chart can be installed directly with Helm or any other common Kubernetes dep
 If installing with Helm directly, the following command will install the chart:
 ```console
 helm install <RELEASE_NAME> cloudzero/cloudzero-agent \
-    --set secretName=<NAME_OF_SECRET> \
+    --set existingSecretName=<NAME_OF_SECRET> \
     --set clusterName=<CLUSTER_NAME> \
     --set cloudAccountId=<CLOUD_ACCOUNT_ID> \
 ```
@@ -47,6 +47,13 @@ If using a Secret external to this chart for the API key, ensure the Secret is c
 data:
   value: <API_KEY>
 ```
+
+For example, the Secret could be created with:
+```bash
+kubectl create secret -n example-namespace generic example-secret-name --from-literal=value=<example-api-key-value>
+```
+The Secret can then be used by the agent by giving `example-secret-name` as the Secret name for the `existingSecretName` argument.
+
 ### Metric Exporters
 This chart uses metrics from the [kube-state-metrics](https://github.com/kubernetes/kube-state-metrics) and [node-exporter](https://github.com/prometheus/node_exporter) projects as chart dependencies. By default, these subcharts are disabled so that the agent can scrape metrics from existing instances of `kube-state-metrics` and `node-exporter`. They can optionally be enabled with the settings:
 ```yaml
@@ -76,14 +83,13 @@ See the `kube-state-metrics` [documentation](https://github.com/kubernetes/kube-
 
 ## Values
 
-| Key               | Type   | Default               | Description                                                                                        |
-|-------------------|--------|-----------------------|----------------------------------------------------------------------------------------------------|
-| cloudAccountId    | string | `nil`                 | Account ID of the account the cluster is running in.                                               |
-| clusterName       | string | `nil`                 | Name of the clusters.                                                                              |
-| host              | string | `"api.cloudzero.com"` | CloudZero host to send metrics to.                                                                 |
-| useExistingSecret | bool   | `true`                | If false, a secret containing the CloudZero API key will be created using the `apiKey` value.      |
-| apiKey            | string | `nil`                 | The CloudZero API key to use to export metrics. Only used if `useExistingSecret` is false          |
-| secretName        | string | `""`                  | The name of the secret that contains the CloudZero API key. Required if useExistingSecret is true. |
+| Key               | Type   | Default               | Description                                                                                                             |
+|-------------------|--------|-----------------------|-------------------------------------------------------------------------------------------------------------------------|
+| cloudAccountId    | string | `nil`                 | Account ID of the account the cluster is running in.                                                                    |
+| clusterName       | string | `nil`                 | Name of the clusters.                                                                                                   |
+| host              | string | `"api.cloudzero.com"` | CloudZero host to send metrics to.                                                                                      |
+| apiKey            | string | `nil`                 | The CloudZero API key to use to export metrics. Only used if `existingSecretName` is not set.                           |
+| existingSecretName| string | `nil`                  | The name of the secret that contains the CloudZero API key. Required if not providing the API key via the apiKey value.|
 
 ## Requirements
 

--- a/charts/cloudzero-agent/templates/secret.yaml
+++ b/charts/cloudzero-agent/templates/secret.yaml
@@ -1,7 +1,4 @@
-{{- if .Values.useExistingSecret }}
-  {{- if not .Values.secretName }}
-    {{- fail "'secretName' is required when 'useExistingSecret' is set to true." }}
-  {{- end }}
+{{- if .Values.existingSecretName }}
 {{- else }}
 apiVersion: v1
 kind: Secret
@@ -11,5 +8,5 @@ metadata:
   name: {{ include "cloudzero-agent.secretName" .}}
   namespace: {{ include "cloudzero-agent.namespace" . }}
 data:
-  value: {{ required "An API key is required when not using an existing secret" .Values.apiKey | b64enc | quote }}
+  value: {{ required "An API key is required when not using an existing secret via the existingSecretName argument. Provide an API key with the apiKey argument" .Values.apiKey | b64enc | quote }}
 {{- end }}

--- a/charts/cloudzero-agent/values.yaml
+++ b/charts/cloudzero-agent/values.yaml
@@ -6,10 +6,8 @@ cloudAccountId: null
 clusterName: null
 # -- CloudZero API key. Required if useExistingSecret is false.
 apiKey: null
-# -- If true, a secret containing the CloudZero API key will be created using the `apiKey` value.
-useExistingSecret: true
-# -- The name of the secret that contains the CloudZero API key. Required if useExistingSecret is false.
-secretName: null
+# -- If set, the agent will use the API key in this Secret to authenticate with CloudZero.
+existingSecretName: null
 
 
 promethuesConfig:


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [CloudZero Code of Conduct](https://github.com/cloudzero/template-cloudzero-open-source/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/cloudzero/template-cloudzero-open-source/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

based on chart feedback, using one variable for secret generation, and improving error messages

### Testing

no api key:
```
helm template cz-prom-agent ./  --set clusterName=cirrus-staging --set cloudAccountId=618300337335 --set host=dev-api.cloudzero.com
Error: execution error at (cloudzero-agent/templates/secret.yaml:11:12): An API key is required when not using an existing secret via the existingSecretName argument. Provide an API key with the apiKey argument

Use --debug flag to render out invalid YAML
```
works with secretname:
```
➜  cloudzero-agent git:(CP-18172) helm template cz-prom-agent ./  --set clusterName=cirrus-staging --set cloudAccountId=618300337335 --set host=dev-api.cloudzero.com --set existingSecretName=foobar >/dev/null 2>&1
➜  cloudzero-agent git:(CP-18172) echo $?
0
```

works with apikey:
```
➜  cloudzero-agent git:(CP-18172) helm template cz-prom-agent ./  --set clusterName=cirrus-staging --set cloudAccountId=618300337335 --set host=dev-api.cloudzero.com --set apiKey=foobar >/dev/null 2>&1
➜  cloudzero-agent git:(CP-18172) echo $?
0
```
- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`