### PR TITLE
CP-18124: require clusterName to be RFC1123 compliant

### DIFF
--- a/charts/cloudzero-agent/README.md
+++ b/charts/cloudzero-agent/README.md
@@ -86,7 +86,7 @@ See the `kube-state-metrics` [documentation](https://github.com/kubernetes/kube-
 | Key               | Type   | Default               | Description                                                                                                             |
 |-------------------|--------|-----------------------|-------------------------------------------------------------------------------------------------------------------------|
 | cloudAccountId    | string | `nil`                 | Account ID of the account the cluster is running in.                                                                    |
-| clusterName       | string | `nil`                 | Name of the cluster. Required to be RFC 1035 compliant.                                                                 |
+| clusterName       | string | `nil`                 | Name of the cluster. Required to be RFC 1123 compliant.                                                                 |
 | host              | string | `"api.cloudzero.com"` | CloudZero host to send metrics to.                                                                                      |
 | apiKey            | string | `nil`                 | The CloudZero API key to use to export metrics. Only used if `existingSecretName` is not set.                           |
 | existingSecretName| string | `nil`                  | The name of the secret that contains the CloudZero API key. Required if not providing the API key via the apiKey value.|

--- a/charts/cloudzero-agent/README.md
+++ b/charts/cloudzero-agent/README.md
@@ -86,7 +86,7 @@ See the `kube-state-metrics` [documentation](https://github.com/kubernetes/kube-
 | Key               | Type   | Default               | Description                                                                                                             |
 |-------------------|--------|-----------------------|-------------------------------------------------------------------------------------------------------------------------|
 | cloudAccountId    | string | `nil`                 | Account ID of the account the cluster is running in.                                                                    |
-| clusterName       | string | `nil`                 | Name of the clusters.                                                                                                   |
+| clusterName       | string | `nil`                 | Name of the cluster. Required to be RFC 1035 compliant.                                                                 |
 | host              | string | `"api.cloudzero.com"` | CloudZero host to send metrics to.                                                                                      |
 | apiKey            | string | `nil`                 | The CloudZero API key to use to export metrics. Only used if `existingSecretName` is not set.                           |
 | existingSecretName| string | `nil`                  | The name of the secret that contains the CloudZero API key. Required if not providing the API key via the apiKey value.|

--- a/charts/cloudzero-agent/values.schema.json
+++ b/charts/cloudzero-agent/values.schema.json
@@ -7,7 +7,7 @@
     },
     "clusterName": {
         "type": "string",
-        "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$"
+        "pattern": "^(?![0-9-])(?!.*--)[a-zA-Z0-9-]{1,63}(?<!-)$"
     },
     "cloudAccountId": {
         "type": [

--- a/charts/cloudzero-agent/values.schema.json
+++ b/charts/cloudzero-agent/values.schema.json
@@ -7,7 +7,7 @@
     },
     "clusterName": {
         "type": "string",
-        "pattern": "^[a-zA-Z0-9](?:[a-zA-Z0-9.-]{0,61}[a-zA-Z0-9])?$"
+        "pattern": "^[a-zA-Z0-9](?:[a-zA-Z0-9.-]{0,253}[a-zA-Z0-9])?$"
     },
     "cloudAccountId": {
         "type": [

--- a/charts/cloudzero-agent/values.schema.json
+++ b/charts/cloudzero-agent/values.schema.json
@@ -7,7 +7,7 @@
     },
     "clusterName": {
         "type": "string",
-        "pattern": "^(?![0-9-])(?!.*--)[a-zA-Z0-9-]{1,63}(?<!-)$"
+        "pattern": "^[a-zA-Z0-9](?:[a-zA-Z0-9.-]{0,61}[a-zA-Z0-9])?$"
     },
     "cloudAccountId": {
         "type": [


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [CloudZero Code of Conduct](https://github.com/cloudzero/template-cloudzero-open-source/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/cloudzero/template-cloudzero-open-source/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

while a k8s cluster itself does not have a concept of naming, cloud providers and k8s management tools do. the naming requirements may vary between them, but RFC 1035 should be a good criteria for naming. really, we want to be permissive in what users name their clusters, but also make sure users don't enter totally invalid characters


### References

https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#rfc-1035-label-names

### Testing

as an example:

```
➜ helm template foo-agent ./  --set clusterName=valid-name --set cloudAccountId=12345 --set apiKey=foobar >/dev/null
➜  helm template foo-agent ./  --set clusterName=valid-name.com --set cloudAccountId=12345 --set apiKey=foobar >/dev/null
➜  helm template foo-agent ./  --set clusterName=valid-name.with.subdomain.com --set cloudAccountId=12345 --set apiKey=foobar >/dev/null
```
invalid names:
```
➜  helm template foo-agent ./  --set clusterName=invalid_name --set cloudAccountId=12345 --set apiKey=foobar >/dev/null
Error: values don't meet the specifications of the schema(s) in the following chart(s):
cloudzero-agent:
- clusterName: Does not match pattern '^[a-zA-Z0-9](?:[a-zA-Z0-9.-]{0,253}[a-zA-Z0-9])?$'

➜   helm template foo-agent ./  --set clusterName=.invalidname. --set cloudAccountId=12345 --set apiKey=foobar >/dev/null
Error: values don't meet the specifications of the schema(s) in the following chart(s):
cloudzero-agent:
- clusterName: Does not match pattern '^[a-zA-Z0-9](?:[a-zA-Z0-9.-]{0,253}[a-zA-Z0-9])?$'
```

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`