### PR TITLE
CP-18233: existingSecretName should be used in secretName

### DIFF
--- a/charts/cloudzero-agent/CHANGELOG.md
+++ b/charts/cloudzero-agent/CHANGELOG.md
@@ -8,4 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.0.1] - 2024-03-27
+## [0.0.2]
+
+### Fixed
+- `existingSecretName` is used in the `secretName` named template so that the deployment uses the correct Secret
+- `cloudAccountId` is coerced to a string to prevent malformed `cloud_account_id` query params
+
+## [0.0.1]
+
+### Added
+- Initial release

--- a/charts/cloudzero-agent/templates/_helpers.tpl
+++ b/charts/cloudzero-agent/templates/_helpers.tpl
@@ -14,7 +14,7 @@ Create chart name and version as used by the chart label.
 
 {{/* Define the secret name which holds the CloudZero API key */}}
 {{ define "cloudzero-agent.secretName" -}}
-{{ .Values.secretName | default (printf "%s-api-key" .Release.Name) }}
+{{ .Values.existingSecretName | default (printf "%s-api-key" .Release.Name) }}
 {{- end}}
 
 {{ define "cloudzero-agent.configMapName" -}}

--- a/charts/cloudzero-agent/templates/cm.yaml
+++ b/charts/cloudzero-agent/templates/cm.yaml
@@ -136,7 +136,7 @@ data:
           follow_redirects: true
           enable_http2: true
     remote_write:
-      - url: 'https://{{ .Values.host }}/v1/container-metrics?cluster_name={{.Values.clusterName}}&cloud_account_id={{.Values.cloudAccountId}}'
+      - url: 'https://{{ .Values.host }}/v1/container-metrics?cluster_name={{.Values.clusterName}}&cloud_account_id={{.Values.cloudAccountId | toString}}'
         authorization:
           credentials_file: /etc/config/prometheus/secrets/value
         write_relabel_configs:


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [CloudZero Code of Conduct](https://github.com/cloudzero/template-cloudzero-open-source/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/cloudzero/template-cloudzero-open-source/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

we should use the `existingSecretName` as the secret external name

### Testing

some examples:
```
helm template foo-agent ./  --set clusterName='foo' --set cloudAccountId=12345.321 --set existingSecretName=foobar | grep 'secret:' -A 1
          secret:
            secretName: foobar
```
without existing secret:
```
helm template foo-agent ./  --set clusterName='foo' --set cloudAccountId=12345.321 --set apiKey=foobar | grep 'secret:' -A 1
          secret:
            secretName: foo-agent-api-key
```

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`