### PR TITLE
CP-18243: Coerce cloudAccountId to String

### DIFF
--- a/charts/cloudzero-agent/templates/cm.yaml
+++ b/charts/cloudzero-agent/templates/cm.yaml
@@ -136,7 +136,7 @@ data:
           follow_redirects: true
           enable_http2: true
     remote_write:
-      - url: 'https://{{ .Values.host }}/v1/container-metrics?cluster_name={{.Values.clusterName}}&cloud_account_id={{.Values.cloudAccountId}}'
+      - url: 'https://{{ .Values.host }}/v1/container-metrics?cluster_name={{.Values.clusterName}}&cloud_account_id={{.Values.cloudAccountId | toString}}'
         authorization:
           credentials_file: /etc/config/prometheus/secrets/value
         write_relabel_configs:


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [CloudZero Code of Conduct](https://github.com/cloudzero/template-cloudzero-open-source/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/cloudzero/template-cloudzero-open-source/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

This PR ensures that `cloudAccountId` is always a string. With the new changes, specifying a somewhat large integer results in:
``` bash
cloudzero-agent-server ts=2024-04-24T15:05:27.382Z caller=dedupe.go:112 component=remote level=info remote_name=e667d6 url="https://dev-api.cloudzero.com/v1/container-metrics?cluster_name=bdren-agent-operator&cloud_account_id=100023459849829342" msg="Done replaying WAL" duration=20.141377454s    

```

### Checklist

- [n/a] I have added documentation for new/changed functionality in this PR
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`