### PR TITLE
CP-19226: Merge Metric Lists Correctly 

### DIFF
--- a/charts/cloudzero-agent/CHANGELOG.md
+++ b/charts/cloudzero-agent/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.0.5]
+## [0.0.6]
 ### Fixed
 - Failure to scrape for container metrics due to improper joining of kubeMetrics and containerMetrics.
 

--- a/charts/cloudzero-agent/CHANGELOG.md
+++ b/charts/cloudzero-agent/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.5]
+### Fixed
+- Failure to scrape for container metrics due to improper joining of kubeMetrics and containerMetrics.
+
 
 ## [0.0.4]
 ### Added

--- a/charts/cloudzero-agent/Chart.yaml
+++ b/charts/cloudzero-agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cloudzero-agent
 description: A chart for using Prometheus in agent mode to send cluster metrics to the CloudZero platform.
 type: application
-version: 0.0.3
+version: 0.0.6
 appVersion: "v2.50.1"
 dependencies:
   - name: kube-state-metrics

--- a/charts/cloudzero-agent/templates/_helpers.tpl
+++ b/charts/cloudzero-agent/templates/_helpers.tpl
@@ -115,7 +115,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 Combine metric lists
 */}}
 {{- define "chartname.combineMetrics" -}}
-{{- $total := append .Values.kubeMetrics .Values.containerMetrics -}}
+{{- $total := concat .Values.kubeMetrics .Values.containerMetrics -}}
 {{- $result := join "|" $total -}}
 {{- $result -}}
 {{- end -}}


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [CloudZero Code of Conduct](https://github.com/cloudzero/template-cloudzero-open-source/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/cloudzero/template-cloudzero-open-source/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

This PR addresses the failure of container metrics from being scraped. 

### Testing

Using `helm template`, to validate that the `remote_write` regex list is formatted correctly:

After:
``` yaml
  remote_write:
      - url: 'https://api.cloudzero.com/v1/container-metrics?cluster_name=foo&cloud_account_id=100000'
        authorization:
          credentials_file: /etc/config/prometheus/secrets/value
        write_relabel_configs:
          - source_labels: [__name__]
            regex: "^(kube_node_info|kube_node_status_capacity|kube_pod_container_resource_limits|kube_pod_container_resource_requests|kube_pod_labels|kube_pod_info|node_cpu_seconds_total|node_dmi_info|container_cpu_usage_seconds_total|container_memory_working_set_bytes|container_network_receive_bytes_total|container_network_transmit_bytes_total)$"
            action: keep
```

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`