### PR TITLE
[CP-19222][CP-19262][CP-19313] add annotations to configmap and secret; remove duplicate resource block

### DIFF
--- a/charts/cloudzero-agent/CHANGELOG.md
+++ b/charts/cloudzero-agent/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Removed duplicate `resources` in deployment
 - Moved `nodeSelector` to `server` block in values.yaml
+- Updated scrape configs to properly drop unused metrics
 
 ## [0.0.6]
 

--- a/charts/cloudzero-agent/CHANGELOG.md
+++ b/charts/cloudzero-agent/CHANGELOG.md
@@ -5,17 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.7]
+
+### Added
+- Arbitrary annotations can be added to the configmap and secret.
+
+### Fixed
+- Removed duplicate `resources` in deployment
+- Moved `nodeSelector` to `server` block in values.yaml
+
 ## [0.0.6]
+
 ### Fixed
 - Failure to scrape for container metrics due to improper joining of kubeMetrics and containerMetrics.
 
-
 ## [0.0.4]
+
 ### Added
 - updated scrape configs to only scrape metrics that are needed
 - added CPU and memory requests and limits to `deploy.yaml` and updated `values.yaml` with suggested values
 - refactored `PVC.yaml` and updated `values.yaml` to match
-
 
 ### Fixed
 - Updated `Exporting Pod Labels` README.md for clarity

--- a/charts/cloudzero-agent/Chart.yaml
+++ b/charts/cloudzero-agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cloudzero-agent
 description: A chart for using Prometheus in agent mode to send cluster metrics to the CloudZero platform.
 type: application
-version: 0.0.7
+version: 0.0.6
 appVersion: "v2.50.1"
 dependencies:
   - name: kube-state-metrics

--- a/charts/cloudzero-agent/Chart.yaml
+++ b/charts/cloudzero-agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cloudzero-agent
 description: A chart for using Prometheus in agent mode to send cluster metrics to the CloudZero platform.
 type: application
-version: 0.0.6
+version: 0.0.7
 appVersion: "v2.50.1"
 dependencies:
   - name: kube-state-metrics

--- a/charts/cloudzero-agent/templates/cm.yaml
+++ b/charts/cloudzero-agent/templates/cm.yaml
@@ -5,6 +5,10 @@ metadata:
     {{- include "cloudzero-agent.server.labels" . | nindent 4 }}
   name: {{ include "cloudzero-agent.configMapName" . }}
   namespace: {{ include "cloudzero-agent.namespace" . }}
+  {{- with .Values.prometheusConfig.configMapAnnotations }}
+  annotations:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
 data:
   prometheus.yml: |-
   {{- if .Values.prometheusConfig.configOverride }}

--- a/charts/cloudzero-agent/templates/cm.yaml
+++ b/charts/cloudzero-agent/templates/cm.yaml
@@ -113,9 +113,6 @@ data:
         follow_redirects: true
         enable_http2: true
         relabel_configs:
-        - source_labels: [__name__]
-          regex: "^({{ join "|" .Values.containerMetrics }})$"
-          action: keep
         - separator: ;
           regex: __meta_kubernetes_node_label_(.+)
           replacement: $1
@@ -137,6 +134,9 @@ data:
         metric_relabel_configs:
         - action: labeldrop
           regex: instance
+        - source_labels: [__name__]
+          regex: "^({{ join "|" .Values.containerMetrics }})$"
+          action: keep
         kubernetes_sd_configs:
         - role: node
           kubeconfig_file: ""

--- a/charts/cloudzero-agent/templates/deploy.yaml
+++ b/charts/cloudzero-agent/templates/deploy.yaml
@@ -58,8 +58,6 @@ spec:
           image: "{{ .Values.server.image.repository }}:{{ .Values.server.image.tag | default .Chart.AppVersion}}"
           {{- end }}
           imagePullPolicy: "{{ .Values.server.image.pullPolicy }}"
-          resources:
-            {{- toYaml .Values.server.resources | nindent 12 }}
           {{- if .Values.server.env }}
           env:
 {{ toYaml .Values.server.env | indent 12}}

--- a/charts/cloudzero-agent/templates/secret.yaml
+++ b/charts/cloudzero-agent/templates/secret.yaml
@@ -7,6 +7,10 @@ metadata:
     {{- include "cloudzero-agent.server.labels" . | nindent 4 }}
   name: {{ include "cloudzero-agent.secretName" .}}
   namespace: {{ include "cloudzero-agent.namespace" . }}
+  {{- with .Values.secretAnnotations }}
+  annotations:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
 data:
   value: {{- $apiKey := .Values.apiKey | toString }}
           {{- if not (regexMatch "^[a-zA-Z0-9-_.~!*'();]+$" $apiKey) }}

--- a/charts/cloudzero-agent/values.yaml
+++ b/charts/cloudzero-agent/values.yaml
@@ -28,6 +28,7 @@ containerMetrics:
 
 prometheusConfig:
   configMapNameOverride: ''
+  configMapAnnotations: {}
   configOverride: ''
 
 kube-state-metrics:
@@ -35,8 +36,10 @@ kube-state-metrics:
 prometheus-node-exporter:
   enabled: false
 
+# -- Annotations to be added to the Secret, if the chart is configured to create one
+secretAnnotations: {}
+
 imagePullSecrets: []
-nodeSelector: {}
 server:
   name: server
   image:
@@ -46,6 +49,7 @@ server:
     # When digest is set to a non-empty value, images will be pulled by digest (regardless of tag value).
     digest: ""
     pullPolicy: IfNotPresent
+  nodeSelector: {}
   resources:
     requests:
       memory: 512Mi


### PR DESCRIPTION
### Description

- users can now add annotations to the secret and configmap created by the agent chart
- duplicate resource block removed
- nodeselector field moved to correct place in values.yaml
- scrape config updated to drop unused metrics


### Testing
#### testing annotations
Given the input file:
```yaml
prometheusConfig:
  configMapAnnotations:
    foo.bar/bat: baz
secretAnnotations:
  this.is/cool: "true"
```

installing with:
```bash
helm upgrade --install cz-prom-agent ./ ... -f my-test-file.yaml
```
given annotations are set on the cm and secret:
```bash
kg cm cz-prom-agent-configuration -o yaml | grep -i annotations -A 4
  annotations:
    foo.bar/bat: baz
    meta.helm.sh/release-name: cz-prom-agent
    meta.helm.sh/release-namespace: default
```

```bash
 kg secret cz-prom-agent-api-key -o yaml | grep metadata -A 6
metadata:
  annotations:
    this.is/cool: "true"
    meta.helm.sh/release-name: cz-prom-agent
    meta.helm.sh/release-namespace: default
```

#### testing scrape config
after deploying the chart without agent mode enabled and port-forwarding prometheus to localhost:

```
curl -g 'http://localhost:9090/api/v1/label/__name__/values' | tr ',' '\n' | tr '[' '\n' | grep -E '"container'

"container_cpu_usage_seconds_total"
"container_memory_working_set_bytes"
"container_network_receive_bytes_total"
"container_network_transmit_bytes_total


- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`