### PR TITLE
[CP-19158]: Add ecosystem validation support

### DIFF
--- a/charts/cloudzero-agent/docs/deploy-validation.md
+++ b/charts/cloudzero-agent/docs/deploy-validation.md
@@ -1,0 +1,69 @@
+# How to Validate Deployment
+
+This guide provides instructions on how to validate the deployment of the Helm chart. As part of the deployment, a container is started to execute environmental validations. This guide outlines how to use these to gather insight into if everything is ready post deployment.
+
+## Steps to Validate the Deployment
+
+1. **Get the Pod Name**: After deploying the Helm chart, you need to identify the pod running the `env-validator`. Use the following command to list all pods in the namespace where you have deployed the chart:
+
+    ```sh
+    kubectl -n kube-system get pods
+    ```
+
+The output of this should be similar to as follows, with your specific helm release name (r1):
+```bash
+NAME                                          READY   STATUS        RESTARTS   AGE
+r1-cloudzero-agent-server-6dc588f9cb-zfvr7   0/2     Terminating   0          31s
+r1-prometheus-node-exporter-69kg8            1/1     Running       0          5s
+r1-kube-state-metrics-79894f6c55-q5rq4       0/1     Running       0          5s
+r1-cloudzero-agent-server-6dc588f9cb-qqqm9   0/2     Init:0/1      0          5s
+``` 
+
+
+2. **Check Validation Results**: Once you have the pod name, you can check the validation results by viewing the logs of the `env-validator` container. Replace `<pod-name>` with the actual pod name obtained from the previous step:
+
+    ```sh
+    kubectl -n kube-system logs -f -c env-validator <pod-name>
+    ```
+
+### Example Output
+
+The expected output of the `env-validator` will look something like the following. 
+
+```plaintext
+$ kubectl -n kube-system logs -f -c env-validator r1-cloudzero-agent-server-6dc588f9cb-zfvr7
+Validation starting...
+Collecting requests==2.32.3 (from -r requirements.txt (line 1))
+Downloading requests-2.32.3-py3-none-any.whl.metadata (4.6 kB)
+Collecting charset-normalizer<4,>=2 (from requests==2.32.3->-r requirements.txt (line 1))
+Downloading charset_normalizer-3.3.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl.metadata (33 kB)
+Collecting idna<4,>=2.5 (from requests==2.32.3->-r requirements.txt (line 1))
+Downloading idna-3.7-py3-none-any.whl.metadata (9.9 kB)
+Collecting urllib3<3,>=1.21.1 (from requests==2.32.3->-r requirements.txt (line 1))
+Downloading urllib3-2.2.1-py3-none-any.whl.metadata (6.4 kB)
+Collecting certifi>=2017.4.17 (from requests==2.32.3->-r requirements.txt (line 1))
+Downloading certifi-2024.6.2-py3-none-any.whl.metadata (2.2 kB)
+Downloading requests-2.32.3-py3-none-any.whl (64 kB)
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 64.9/64.9 kB 4.9 MB/s eta 0:00:00
+Downloading certifi-2024.6.2-py3-none-any.whl (164 kB)
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 164.4/164.4 kB 4.7 MB/s eta 0:00:00
+Downloading charset_normalizer-3.3.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl (137 kB)
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 137.3/137.3 kB 13.3 MB/s eta 0:00:00
+Downloading idna-3.7-py3-none-any.whl (66 kB)
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 66.8/66.8 kB 9.1 MB/s eta 0:00:00
+Downloading urllib3-2.2.1-py3-none-any.whl (121 kB)
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 121.1/121.1 kB 12.0 MB/s eta 0:00:00
+Installing collected packages: urllib3, idna, charset-normalizer, certifi, requests
+Successfully installed certifi-2024.6.2 charset-normalizer-3.3.2 idna-3.7 requests-2.32.3 urllib3-2.2.1
+Running validations...
+http://r1-kube-state-metrics:8080/ not ready yet
+------------------------------------------------------------
+CHECK                                              RESULT
+external_connectivity_available                    success
+kube_state_metrics_available                       success
+prometheus_node_exporter_available                 success
+------------------------------------------------------------
+Validator finished.
+```
+
+If all checks show `success`, the deployment is validated successfully.

--- a/charts/cloudzero-agent/templates/check-cm.yaml
+++ b/charts/cloudzero-agent/templates/check-cm.yaml
@@ -1,0 +1,100 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: validator
+data:
+  script.sh: |
+    set -e;
+    echo 'Validation starting...';
+    python -m venv /app/venv;
+    export PATH='/app/venv/bin:$PATH';
+    pip install -r requirements.txt;
+    echo 'Running validations...';
+    ./validate.sh;
+    echo 'Validator finished.'
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: validator-requirements
+data:
+  requirements.txt: |
+    requests==2.32.3
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: validator-script
+data:
+  validate.sh: |
+    #!/usr/bin/env python3
+
+    import os
+    import requests
+    import sys
+    import time
+    from typing import Tuple, Dict
+
+    def check_service_availability(url: str, key: str) -> Tuple[str, str]:
+      MAX_RETRY = 6
+      RETRY_INTERVAL = 30
+
+      for _ in range(MAX_RETRY):
+        try:
+          response = requests.get(url)
+          response.raise_for_status()
+          return (key, 'success')
+        except Exception as e:
+          print(f'{url} not ready', file=sys.stderr)
+          time.sleep(RETRY_INTERVAL)
+
+      print(f'{key} not ready after {MAX_RETRY} retries', file=sys.stderr)
+      return (key, 'failure')
+
+    def check_kube_state_metrics() -> Tuple[str, str]:
+      namespace: str = os.getenv('NAMESPACE', 'default')
+      url: str = os.getenv('KMS_URL', f'http://kube-state-metrics.{namespace}.svc.cluster.local:8080/')
+      return check_service_availability(url, 'has_kube_state_metrics')
+
+    def check_external_connectivity() -> Tuple[str, str]:
+      host: str = os.getenv('CZ_HOST', 'api.cloudzero.com')
+      url: str = f'http://{host}'
+      return check_service_availability(url, 'external_connectivity')
+
+    validations = [
+      check_external_connectivity, 
+      check_kube_state_metrics, 
+    ]
+
+    def run_validations() -> Dict[str, str]:
+      results: Dict[str, str] = {}
+      for check in validations:
+        check_name: str = check.__name__
+        key, value = check()
+        results[key] = value
+      return results
+
+    def must_pass(results: Dict[str, str]):
+      for check, result in results.items():
+        if result != 'success':
+          exit(1)
+
+    def print_results(results: Dict[str, str]) -> None:
+      print('---------------------------------------------')
+      print ('{:<25} {:<10}'.format('CHECK', 'RESULT'))
+      for check, result in results.items():
+        print('{:<25} {:<10}'.format(check, result))
+      print('---------------------------------------------')
+
+    def main():
+      results = run_validations()
+      
+      print_results(results)
+
+      # TODO - post results to status API endpoint
+      must_pass(results)
+
+    if __name__ == '__main__':
+      main()

--- a/charts/cloudzero-agent/templates/check-cm.yaml
+++ b/charts/cloudzero-agent/templates/check-cm.yaml
@@ -38,8 +38,9 @@ data:
     from typing import Tuple, Dict
 
     def check_service_availability(url: str, key: str) -> Tuple[str, str]:
-      MAX_RETRY = 6
-      RETRY_INTERVAL = 30
+      # only wait two minutes max
+      MAX_RETRY = 12
+      RETRY_INTERVAL = 10
 
       for _ in range(MAX_RETRY):
         try:
@@ -47,25 +48,29 @@ data:
           response.raise_for_status()
           return (key, 'success')
         except Exception as e:
-          print(f'{url} not ready', file=sys.stderr)
+          print(f'{url} not ready yet', file=sys.stderr)
           time.sleep(RETRY_INTERVAL)
 
       print(f'{key} not ready after {MAX_RETRY} retries', file=sys.stderr)
       return (key, 'failure')
 
-    def check_kube_state_metrics() -> Tuple[str, str]:
-      namespace: str = os.getenv('NAMESPACE', 'default')
-      url: str = os.getenv('KMS_URL', f'http://kube-state-metrics.{namespace}.svc.cluster.local:8080/')
-      return check_service_availability(url, 'has_kube_state_metrics')
-
     def check_external_connectivity() -> Tuple[str, str]:
       host: str = os.getenv('CZ_HOST', 'api.cloudzero.com')
       url: str = f'http://{host}'
-      return check_service_availability(url, 'external_connectivity')
+      return check_service_availability(url, 'external_connectivity_available')
+
+    def check_kube_state_metrics() -> Tuple[str, str]:
+      url: str = os.getenv('KMS_EP_URL', f'http://kube-state-metrics:8080/')
+      return check_service_availability(url, 'kube_state_metrics_available')
+
+    def check_prometheus_node_exporter() -> Tuple[str, str]:
+      url: str = os.getenv('NODE_EXPORTER_EP_URL', f'http://prometheus-node-exporter:9100/')
+      return check_service_availability(url, 'prometheus_node_exporter_available')
 
     validations = [
       check_external_connectivity, 
-      check_kube_state_metrics, 
+      check_kube_state_metrics,
+      check_prometheus_node_exporter,
     ]
 
     def run_validations() -> Dict[str, str]:
@@ -82,11 +87,11 @@ data:
           exit(1)
 
     def print_results(results: Dict[str, str]) -> None:
-      print('---------------------------------------------')
-      print ('{:<25} {:<10}'.format('CHECK', 'RESULT'))
+      print('-' * 60)
+      print('{:<50} {:<10}'.format('CHECK', 'RESULT'))
       for check, result in results.items():
-        print('{:<25} {:<10}'.format(check, result))
-      print('---------------------------------------------')
+        print('{:<50} {:<10}'.format(check, result))
+      print('-' * 60)
 
     def main():
       results = run_validations()

--- a/charts/cloudzero-agent/templates/deploy.yaml
+++ b/charts/cloudzero-agent/templates/deploy.yaml
@@ -44,8 +44,10 @@ spec:
           env:
             - name: NAMESPACE
               value: metadata.namespace
-            - name: KMS_URL
-              value: http://{{- if .Release.Name }}{{.Release.Name}}-{{- end }}kube-state-metrics.svc.cluster.local:8080/
+            - name: KMS_EP_URL
+              value: http://{{- if .Release.Name }}{{.Release.Name}}-{{- end }}kube-state-metrics:8080/
+            - name: NODE_EXPORTER_EP_URL
+              value: http://{{- if .Release.Name }}{{.Release.Name}}-{{- end }}prometheus-node-exporter:9100/
             - name: CZ_HOST
               value: {{ .Values.host }}
           volumeMounts:

--- a/charts/cloudzero-agent/templates/deploy.yaml
+++ b/charts/cloudzero-agent/templates/deploy.yaml
@@ -30,6 +30,34 @@ spec:
       priorityClassName: "{{ .Values.server.priorityClassName }}"
 {{- end }}
       serviceAccountName: {{ template "cloudzero-agent.serviceAccountName.server" . }}
+      initContainers:
+        - name: env-validator
+          image: python:3.12-slim
+          workingDir: /app
+          # TODO: create container image, root required to install packages atm
+          securityContext:
+            runAsUser: 0
+            runAsNonRoot: false
+            runAsGroup: 0
+            fsGroup: 0
+          command: ["sh", "-c", "/app/script.sh"]
+          env:
+            - name: NAMESPACE
+              value: metadata.namespace
+            - name: KMS_URL
+              value: http://{{- if .Release.Name }}{{.Release.Name}}-{{- end }}kube-state-metrics.svc.cluster.local:8080/
+            - name: CZ_HOST
+              value: {{ .Values.host }}
+          volumeMounts:
+            - name: validator-volume
+              mountPath: /app/script.sh
+              subPath: script.sh
+            - name: validator-requirements-volume
+              mountPath: /app/requirements.txt
+              subPath: requirements.txt
+            - name: validator-script-volume
+              mountPath: /app/validate.sh
+              subPath: validate.sh
       containers:
         {{- if .Values.configmapReload.prometheus.enabled }}
         - name: {{ template "cloudzero-agent.name" . }}-{{ .Values.server.name }}-configmap-reload
@@ -136,6 +164,17 @@ spec:
         - name: cloudzero-api-key
           secret:
             secretName: {{ include "cloudzero-agent.secretName" . }}
+        - name: validator-volume
+          configMap:
+            name: validator
+            defaultMode: 0700
+        - name: validator-requirements-volume
+          configMap:
+            name: validator-requirements
+        - name: validator-script-volume
+          configMap:
+            name: validator-script
+            defaultMode: 0700
         - name: cloudzero-agent-storage-volume
         {{- if .Values.server.persistentVolume.enabled }}
           persistentVolumeClaim:


### PR DESCRIPTION
### Description

- deploy now validates external communication, kms, and prom-node-exporter are available.
- how-to check validation results

### Testing

Testing requires using different value to enable/disable KSM or Prom Node Exporter as follows. Each one will result in either success, or relative failure validation.

**1. Golden path (all pass)**
   ```bash
   helm install cza . \
      --namespace cz-cirrus-agent \
      --set existingSecretName=api-token \
      --set clusterName=cz-cirrus-jb \
      --set cloudAccountId=247742 \
      --set kube-state-metrics.enabled=true \
      --set prometheus-node-exporter.enabled=true
```

OR

**1. missing kube-state-metrics test**
   ```bash
   helm install cza . \
      --namespace cz-cirrus-agent \
      --set existingSecretName=api-token \
      --set clusterName=cz-cirrus-jb \
      --set cloudAccountId=247742 \
      --set prometheus-node-exporter.enabled=true
```
OR

**1. OR missing prometheus-node-exporter test**
   ```bash
   helm install cza . \
      --namespace cz-cirrus-agent \
      --set existingSecretName=api-token \
      --set clusterName=cz-cirrus-jb \
      --set cloudAccountId=247742 \
      --set kube-state-metrics.enabled=true
```


**2. Next, get the pod name**
```bash
k -n cz-cirrus-agent get pods
```

**2. Using the `cloudzero-agent-server` pod to watch the `env-validator` container"**
```bash
k -n cz-cirrus-agent logs -f -c env-validator cza-cloudzero-agent-server-6dc588f9cb-kphcn
```

**3. Cleanup the installation:**
```bash
helm uninstall cza --namespace cz-cirrus-agent
```

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`