### PR TITLE
Cp 19161 ensure we have good testing on new validator code

### DIFF
--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -25,7 +25,7 @@ jobs:
       contents: read
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
     - name: SETUP - Checkout
       if: needs.has_changes.outputs.any_changed == 'true'

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -1,0 +1,48 @@
+name: test_python
+on:
+  push:
+  pull_request:
+
+env:
+  # build docker images to the (host) local registry
+  REGISTRY_LOCAL_ADDR: localhost:5000
+  # k8x requires the kind container address alias (comes from the kind-action)
+  REGISTRY_TEST_ADDR: kind-registry:5000
+  # If we are on develop or main, use the production repository
+  REGISTRY_PROD_ADDR: ghcr.io
+  # image name should be prefixed with the repository name
+  IMAGE_NAME: ${{ github.repository }}/cloudzero-agent-validator
+  
+jobs:
+  # This job detects if there are any changes to allow condition testing in other jobs
+  has_changes:
+    uses: ./.github/workflows/change-detector.yml
+  
+  test_python:
+    runs-on: ubuntu-latest
+    needs: has_changes
+    permissions:
+      contents: read
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10"]
+    steps:
+    - name: SETUP - Checkout
+      if: needs.has_changes.outputs.any_changed == 'true'
+      uses: actions/checkout@v4
+
+    - name: SETUP - Python ${{ matrix.python-version }}
+      if: needs.has_changes.outputs.any_changed == 'true'
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: SETUP - Display Python version
+      if: needs.has_changes.outputs.any_changed == 'true'
+      run: |
+        python -c "import sys; print(sys.version)"
+
+    - name: TEST - Run checks
+      run: |
+        cd charts/cloudzero-agent
+        make check

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -25,7 +25,7 @@ jobs:
       contents: read
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.12"]
     steps:
     - name: SETUP - Checkout
       if: needs.has_changes.outputs.any_changed == 'true'

--- a/charts/cloudzero-agent/Makefile
+++ b/charts/cloudzero-agent/Makefile
@@ -82,6 +82,14 @@ clean: ## Clean up dangling Docker images
 fmt: init-dev ## runs code formatter
 	@$(PYTHON_ARGS) black $(SRC_DIR)/*.py $(TEST_DIR)/*.py
 
+.PHONY: fmt-check
+fmt-check: ## Check if the code is properly formatted
+	if [ $$(git status -s | wc -c) -ne 0 ]; then \
+		echo "The following files are not properly formatted:"; \
+		git status -s; \
+		exit 1; \
+	fi
+
 .PHONY: lint
 lint: init-dev ## runs code linter
 	@$(PYTHON_ARGS) ruff check $(SRC_DIR) $(TEST_DIR)

--- a/charts/cloudzero-agent/Makefile
+++ b/charts/cloudzero-agent/Makefile
@@ -85,16 +85,14 @@ fmt: init-dev ## runs code formatter
 .PHONY: fmt-check
 fmt-check: fmt ## Check if the code is properly formatted
 	$(eval CHANGED := $(shell git status -s | grep "\.py" | wc -c))
-ifneq ($(CHANGED),0)
-	@exit 1
-endif
+	@[ $(CHANGED) -eq 0 ] || { echo "changed files"; exit 1; }
 
 .PHONY: lint
 lint: init-dev ## runs code linter
 	@$(PYTHON_ARGS) ruff check $(SRC_DIR) $(TEST_DIR)
 
 .PHONY: check
-check: lint test ## Run code linter and unit tests
+check: fmt-check lint test ## Run code linter and unit tests
 
 .PHONY: test
 test: check-python-version init-dev ## Run unit tests

--- a/charts/cloudzero-agent/Makefile
+++ b/charts/cloudzero-agent/Makefile
@@ -83,12 +83,11 @@ fmt: init-dev ## runs code formatter
 	@$(PYTHON_ARGS) black $(SRC_DIR)/*.py $(TEST_DIR)/*.py
 
 .PHONY: fmt-check
-fmt-check: ## Check if the code is properly formatted
-	if [ $$(git status -s | wc -c) -ne 0 ]; then \
-		echo "The following files are not properly formatted:"; \
-		git status -s; \
-		exit 1; \
-	fi
+fmt-check: fmt ## Check if the code is properly formatted
+	$(eval CHANGED := $(shell git status -s | grep "\.py" | wc -c))
+ifneq ($(CHANGED),0)
+	@exit 1
+endif
 
 .PHONY: lint
 lint: init-dev ## runs code linter

--- a/charts/cloudzero-agent/src/validate.py
+++ b/charts/cloudzero-agent/src/validate.py
@@ -24,7 +24,6 @@ def check_service_availability(url: str, key: str) -> Tuple[str, str]:
     print(f"{key} not ready after {MAX_RETRY} retries", file=sys.stderr)
     return (key, "failure")
 
-
 def check_external_connectivity() -> Tuple[str, str]:
     host: str = os.getenv("CZ_HOST", "api.cloudzero.com")
     url: str = f"http://{host}"

--- a/charts/cloudzero-agent/src/validate.py
+++ b/charts/cloudzero-agent/src/validate.py
@@ -24,6 +24,7 @@ def check_service_availability(url: str, key: str) -> Tuple[str, str]:
     print(f"{key} not ready after {MAX_RETRY} retries", file=sys.stderr)
     return (key, "failure")
 
+
 def check_external_connectivity() -> Tuple[str, str]:
     host: str = os.getenv("CZ_HOST", "api.cloudzero.com")
     url: str = f"http://{host}"


### PR DESCRIPTION
### Description

This PR adds:
1. A check to the Makefile to ensure we have no formatting changes
2. A github pipeline to run the `makefile check`  target. 

### Testing

This PR CI is the testing, however if you'd like to run it manually do the following:
```bash
git clone git@github.com:josephbarnett/cloudzero-charts.git cloudzero-charts-jb
cd cloudzero-charts-jb
git checkout CP-19161-ensure-we-have-good-testing-on-new-validator-code
act -j test_python 
```

Note, you will need docker, and [act utility](https://github.com/nektos/act) installed.

<details>
   <summary>Manual Test Results</summary>
    
   ```bash
   $ act -j test_python 
   INFO[0000] Using docker host 'unix:///var/run/docker.sock', and daemon socket 'unix:///var/run/docker.sock' 
   [has_changes/detection_rules/scanner] 🚀  Start image=catthehacker/ubuntu:act-latest
   [has_changes/detection_rules/scanner]   🐳  docker pull image=catthehacker/ubuntu:act-latest platform=linux/amd64 username= forcePull=true
   [has_changes/detection_rules/scanner] using DockerAuthConfig authentication for docker pull
   [has_changes/detection_rules/scanner]   🐳  docker create image=catthehacker/ubuntu:act-latest platform=linux/amd64 entrypoint=["tail" "-f" "/dev/null"] cmd=[] network="host"
   [has_changes/detection_rules/scanner]   🐳  docker run image=catthehacker/ubuntu:act-latest platform=linux/amd64 entrypoint=["tail" "-f" "/dev/null"] cmd=[] network="host"
   [has_changes/detection_rules/scanner]   ☁  git clone 'https://github.com/tj-actions/changed-files' # ref=v44
   [has_changes/detection_rules/scanner] Non-terminating error while running 'git clone': some refs were not updated
   [has_changes/detection_rules/scanner] ⭐ Run Main Checkout
   [has_changes/detection_rules/scanner]   🐳  docker cp src=/Users/joe.barnett/company/code/cloudzero-charts-jb/. dst=/Users/joe.barnett/company/code/cloudzero-charts-jb
   [has_changes/detection_rules/scanner]   ✅  Success - Main Checkout
   [has_changes/detection_rules/scanner] ⭐ Run Main Detect if any files have changed
   [has_changes/detection_rules/scanner]   🐳  docker cp src=/Users/joe.barnett/.cache/act/tj-actions-changed-files@v44/ dst=/var/run/act/actions/tj-actions-changed-files@v44/
   [has_changes/detection_rules/scanner]   🐳  docker exec cmd=[node /var/run/act/actions/tj-actions-changed-files@v44/dist/index.js] user= workdir=
   [has_changes/detection_rules/scanner]   ❓  ::group::changed-files
   [has_changes/detection_rules/scanner]   💬  ::debug::Env: {%0A  "PATH": "/opt/acttoolcache/node/18.20.3/x64/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin",%0A  "HOSTNAME": "docker-desktop",%0A  "TERM": "xterm",%0A  "RUNNER_TOOL_CACHE": "/opt/hostedtoolcache",%0A  "RUNNER_OS": "Linux",%0A  "RUNNER_ARCH": "ARM64",%0A  "RUNNER_TEMP": "/tmp",%0A  "LANG": "C.UTF-8",%0A  "DEBIAN_FRONTEND": "noninteractive",%0A  "IMAGE_OS": "ubuntu22",%0A  "ImageOS": "ubuntu20",%0A  "LSB_RELEASE": "22.04",%0A  "AGENT_TOOLSDIRECTORY": "/opt/hostedtoolcache",%0A  "RUN_TOOL_CACHE": "/opt/hostedtoolcache",%0A  "DEPLOYMENT_BASEPATH": "/opt/runner",%0A  "USER": "root",%0A  "RUNNER_USER": "root",%0A  "ACT_TOOLSDIRECTORY": "/opt/acttoolcache",%0A  "LSB_OS_VERSION": "2204",%0A  "GITHUB_WORKFLOW": "detection_rules",%0A  "GITHUB_REPOSITORY_OWNER": "josephbarnett",%0A  "INPUT_EXCLUDE_SUBMODULES": "false",%0A  "INPUT_DIR_NAMES_EXCLUDE_CURRENT_DIR": "false",%0A  "INPUT_FETCH_ADDITIONAL_SUBMODULE_HISTORY": "false",%0A  "GITHUB_WORKSPACE": "/Users/joe.barnett/company/code/cloudzero-charts-jb",%0A  "GITHUB_REF_TYPE": "branch",%0A  "GITHUB_HEAD_REF": "",%0A  "GITHUB_STATE": "/var/run/act/workflow/statecmd.txt",%0A  "INPUT_NEGATION_PATTERNS_FIRST": "false",%0A  "INPUT_RECOVER_DELETED_FILES_TO_DESTINATION": "",%0A  "GITHUB_RUN_NUMBER": "1",%0A  "GITHUB_ACTION_REF": "v44",%0A  "INPUT_SAFE_OUTPUT": "true",%0A  "INPUT_SEPARATOR": " ",%0A  "INPUT_RECOVER_FILES": "",%0A  "INPUT_SINCE": "",%0A  "INPUT_DIR_NAMES": "false",%0A  "GITHUB_ACTION_REPOSITORY": "tj-actions/changed-files",%0A  "GITHUB_EVENT_NAME": "push",%0A  "GITHUB_STEP_SUMMARY": "/var/run/act/workflow/SUMMARY.md",%0A  "INPUT_RECOVER_FILES_SEPARATOR": "\n",%0A  "INPUT_OLD_NEW_SEPARATOR": ",",%0A  "INPUT_FILES_IGNORE_YAML_FROM_SOURCE_FILE_SEPARATOR": "\n",%0A  "INPUT_OLD_NEW_FILES_SEPARATOR": " ",%0A  "INPUT_BASE_SHA": "",%0A  "INPUT_OUTPUT_DIR": ".github/outputs",%0A  "INPUT_PATH": ".",%0A  "INPUT_USE_REST_API": "false",%0A  "INPUT_FETCH_MISSING_HISTORY_MAX_RETRIES": "20",%0A  "INPUT_FILES_YAML_FROM_SOURCE_FILE": "",%0A  "INPUT_FILES_SEPARATOR": "\n",%0A  "ACT": "true",%0A  "GITHUB_ACTION_PATH": "",%0A  "GITHUB_ACTIONS": "true",%0A  "GITHUB_REF": "refs/heads/CP-19161-ensure-we-have-good-testing-on-new-validator-code",%0A  "GITHUB_REF_NAME": "CP-19161-ensure-we-have-good-testing-on-new-validator-code",%0A  "INPUT_DIR_NAMES_INCLUDE_FILES": "",%0A  "INPUT_SINCE_LAST_REMOTE_COMMIT": "false",%0A  "INPUT_OUTPUT_RENAMED_FILES_AS_DELETED_AND_ADDED": "false",%0A  "INPUT_RECOVER_DELETED_FILES": "false",%0A  "INPUT_FAIL_ON_SUBMODULE_DIFF_ERROR": "false",%0A  "INPUT_TAGS_PATTERN": "*",%0A  "INPUT_FILES_YAML": "",%0A  "INPUT_UNTIL": "",%0A  "INPUT_DIR_NAMES_MAX_DEPTH": "",%0A  "INPUT_MATRIX": "false",%0A  "INPUT_FILES_FROM_SOURCE_FILE_SEPARATOR": "\n",%0A  "INPUT_DIR_NAMES_DELETED_FILES_INCLUDE_ONLY_DELETED_DIRS": "false",%0A  "INPUT_DIR_NAMES_INCLUDE_FILES_SEPARATOR": "\n",%0A  "INPUT_INCLUDE_ALL_OLD_NEW_RENAMED_FILES": "false",%0A  "GITHUB_API_URL": "https://api.github.com",%0A  "GITHUB_GRAPHQL_URL": "https://api.github.com/graphql",%0A  "GITHUB_PATH": "/var/run/act/workflow/pathcmd.txt",%0A  "GITHUB_ENV": "/var/run/act/workflow/envs.txt",%0A  "INPUT_FILES_IGNORE_FROM_SOURCE_FILE_SEPARATOR": "\n",%0A  "INPUT_TOKEN": "",%0A  "INPUT_FILES_YAML_FROM_SOURCE_FILE_SEPARATOR": "\n",%0A  "INPUT_FILES_IGNORE_SEPARATOR": "\n",%0A  "ACTIONS_CACHE_URL": "http://192.168.1.10:55902/",%0A  "GITHUB_REPOSITORY": "josephbarnett/cloudzero-charts",%0A  "GITHUB_RETENTION_DAYS": "0",%0A  "GITHUB_BASE_REF": "",%0A  "INPUT_FILES": "**\n**.md\ncharts/**/docs/**\ncharts/**/tests/**\ncharts/**/src/**\ncharts/**/**.yaml\n",%0A  "INPUT_FILES_IGNORE_YAML": "",%0A  "INPUT_RECOVER_FILES_IGNORE": "",%0A  "INPUT_TAGS_IGNORE_PATTERN": "",%0A  "INPUT_FAIL_ON_INITIAL_DIFF_ERROR": "false",%0A  "GITHUB_EVENT_PATH": "/var/run/act/workflow/event.json",%0A  "GITHUB_JOB": "scanner",%0A  "RUNNER_PERFLOG": "/dev/null",%0A  "GITHUB_SERVER_URL": "https://github.com",%0A  "INPUT_SHA": "",%0A  "INPUT_SKIP_INITIAL_FETCH": "false",%0A  "INPUT_ESCAPE_JSON": "true",%0A  "INPUT_USE_POSIX_PATH_SEPARATOR": "false",%0A  "GITHUB_ACTOR": "nektos/act",%0A  "GITHUB_SHA": "4feaa5e58bf302c08a2d6ef5e7cd1a607221d06d",%0A  "INPUT_FILES_FROM_SOURCE_FILE": "",%0A  "INPUT_DIFF_RELATIVE": "true",%0A  "INPUT_WRITE_OUTPUT_FILES": "false",%0A  "INPUT_FILES_IGNORE_FROM_SOURCE_FILE": "",%0A  "INPUT_RECOVER_FILES_IGNORE_SEPARATOR": "\n",%0A  "GITHUB_RUN_ID": "1",%0A  "INPUT_FILES_IGNORE": "",%0A  "CI": "true",%0A  "RUNNER_TRACKING_ID": "",%0A  "INPUT_QUOTEPATH": "true",%0A  "INPUT_JSON": "false",%0A  "GITHUB_ACTION": "detect",%0A  "GITHUB_OUTPUT": "/var/run/act/workflow/outputcmd.txt",%0A  "INPUT_API_URL": "https://api.github.com",%0A  "INPUT_FETCH_DEPTH": "25",%0A  "INPUT_FILES_IGNORE_YAML_FROM_SOURCE_FILE": "",%0A  "HOME": "/root",%0A  "UV_USE_IO_URING": "0"%0A}
   [has_changes/detection_rules/scanner]   💬  ::debug::Env: {%0A  "GITHUB_REF_NAME": "CP-19161-ensure-we-have-good-testing-on-new-validator-code",%0A  "GITHUB_REF": "refs/heads/CP-19161-ensure-we-have-good-testing-on-new-validator-code",%0A  "GITHUB_WORKSPACE": "/Users/joe.barnett/company/code/cloudzero-charts-jb"%0A}
   [has_changes/detection_rules/scanner]   💬  ::debug::Inputs: {%0A  "files": "**\n**.md\ncharts/**/docs/**\ncharts/**/tests/**\ncharts/**/src/**\ncharts/**/**.yaml",%0A  "filesSeparator": "\n",%0A  "filesFromSourceFile": "",%0A  "filesFromSourceFileSeparator": "\n",%0A  "filesYaml": "",%0A  "filesYamlFromSourceFile": "",%0A  "filesYamlFromSourceFileSeparator": "\n",%0A  "filesIgnore": "",%0A  "filesIgnoreSeparator": "\n",%0A  "filesIgnoreFromSourceFile": "",%0A  "filesIgnoreFromSourceFileSeparator": "\n",%0A  "filesIgnoreYaml": "",%0A  "filesIgnoreYamlFromSourceFile": "",%0A  "filesIgnoreYamlFromSourceFileSeparator": "\n",%0A  "failOnInitialDiffError": false,%0A  "failOnSubmoduleDiffError": false,%0A  "separator": " ",%0A  "sha": "",%0A  "baseSha": "",%0A  "since": "",%0A  "until": "",%0A  "path": ".",%0A  "quotepath": true,%0A  "diffRelative": true,%0A  "sinceLastRemoteCommit": false,%0A  "recoverDeletedFiles": false,%0A  "recoverDeletedFilesToDestination": "",%0A  "recoverFiles": "",%0A  "recoverFilesSeparator": "\n",%0A  "recoverFilesIgnore": "",%0A  "recoverFilesIgnoreSeparator": "\n",%0A  "includeAllOldNewRenamedFiles": false,%0A  "oldNewSeparator": ",",%0A  "oldNewFilesSeparator": " ",%0A  "skipInitialFetch": false,%0A  "fetchAdditionalSubmoduleHistory": false,%0A  "dirNamesDeletedFilesIncludeOnlyDeletedDirs": false,%0A  "excludeSubmodules": false,%0A  "usePosixPathSeparator": false,%0A  "tagsPattern": "*",%0A  "tagsIgnorePattern": "",%0A  "dirNames": false,%0A  "dirNamesExcludeCurrentDir": false,%0A  "dirNamesIncludeFiles": "",%0A  "dirNamesIncludeFilesSeparator": "\n",%0A  "json": false,%0A  "escapeJson": true,%0A  "safeOutput": true,%0A  "writeOutputFiles": false,%0A  "outputDir": ".github/outputs",%0A  "outputRenamedFilesAsDeletedAndAdded": false,%0A  "token": "",%0A  "apiUrl": "https://api.github.com",%0A  "negationPatternsFirst": false,%0A  "useRestApi": false,%0A  "fetchDepth": 25,%0A  "fetchMissingHistoryMaxRetries": 20%0A}
   [has_changes/detection_rules/scanner]   💬  ::debug::Github Context: {%0A  "payload": {},%0A  "eventName": "push",%0A  "sha": "4feaa5e58bf302c08a2d6ef5e7cd1a607221d06d",%0A  "ref": "refs/heads/CP-19161-ensure-we-have-good-testing-on-new-validator-code",%0A  "workflow": "detection_rules",%0A  "action": "detect",%0A  "actor": "nektos/act",%0A  "job": "scanner",%0A  "runNumber": 1,%0A  "runId": 1,%0A  "apiUrl": "https://api.github.com",%0A  "serverUrl": "https://github.com",%0A  "graphqlUrl": "https://api.github.com/graphql"%0A}
   [has_changes/detection_rules/scanner]   💬  ::debug::Working directory: /Users/joe.barnett/company/code/cloudzero-charts-jb
   [has_changes/detection_rules/scanner]   💬  ::debug::Has git directory: true
   [has_changes/detection_rules/scanner]   💬  ::debug::files patterns: **%0A**.md%0Acharts/**/docs/**%0Acharts/**/tests/**%0Acharts/**/src/**%0Acharts/**/**.yaml
   [has_changes/detection_rules/scanner]   💬  ::debug::Input file patterns: %0A**%0A**.md%0Acharts/**/docs/**%0Acharts/**/tests/**%0Acharts/**/src/**%0Acharts/**/**.yaml
   [has_changes/detection_rules/scanner]   💬  ::debug::File patterns: **,**.md,charts/**/docs/**,charts/**/tests/**,charts/**/src/**,charts/**/**.yaml
   [has_changes/detection_rules/scanner]   💬  ::debug::Yaml file patterns: {}
   | Using local .git directory
   | Running on a push event...
   [has_changes/detection_rules/scanner]   💬  ::debug::Getting current SHA...
   [has_changes/detection_rules/scanner]   💬  ::debug::Current SHA: 4feaa5e58bf302c08a2d6ef5e7cd1a607221d06d
   [has_changes/detection_rules/scanner]   💬  ::debug::Getting previous SHA...
   [has_changes/detection_rules/scanner]   💬  ::debug::Getting previous SHA for last remote commit...
   [has_changes/detection_rules/scanner]   💬  ::debug::Previous SHA: 3a1de120dcf668d2625f7699a821d93f7bdb8132
   [has_changes/detection_rules/scanner]   💬  ::debug::Target branch: CP-19161-ensure-we-have-good-testing-on-new-validator-code
   [has_changes/detection_rules/scanner]   💬  ::debug::Current branch: CP-19161-ensure-we-have-good-testing-on-new-validator-code
   | Retrieving changes between 3a1de120dcf668d2625f7699a821d93f7bdb8132 (CP-19161-ensure-we-have-good-testing-on-new-validator-code) → 4feaa5e58bf302c08a2d6ef5e7cd1a607221d06d (CP-19161-ensure-we-have-good-testing-on-new-validator-code)
   [has_changes/detection_rules/scanner]   💬  ::debug::All diff files: {"A":[],"C":[],"D":[],"M":[".github/workflows/test-python.yml"],"R":[],"T":[],"U":[],"X":[]}
   | All Done!
   [has_changes/detection_rules/scanner]   ❓  ::endgroup::
   [has_changes/detection_rules/scanner]   ❓  ::group::changed-files-patterns
   [has_changes/detection_rules/scanner]   💬  ::debug::All filtered diff files: {"A":[],"C":[],"D":[],"M":[".github/workflows/test-python.yml"],"R":[],"T":[],"U":[],"X":[]}
   [has_changes/detection_rules/scanner]   💬  ::debug::Dir names include file patterns: []
   [has_changes/detection_rules/scanner]   💬  ::debug::Added files: {"paths":"","count":"0"}
   [has_changes/detection_rules/scanner]   💬  ::debug::Dir names include file patterns: []
   [has_changes/detection_rules/scanner]   💬  ::debug::Copied files: {"paths":"","count":"0"}
   [has_changes/detection_rules/scanner]   💬  ::debug::Dir names include file patterns: []
   [has_changes/detection_rules/scanner]   💬  ::debug::Modified files: {"paths":".github/workflows/test-python.yml","count":"1"}
   [has_changes/detection_rules/scanner]   💬  ::debug::Dir names include file patterns: []
   [has_changes/detection_rules/scanner]   💬  ::debug::Renamed files: {"paths":"","count":"0"}
   [has_changes/detection_rules/scanner]   💬  ::debug::Dir names include file patterns: []
   [has_changes/detection_rules/scanner]   💬  ::debug::Type changed files: {"paths":"","count":"0"}
   [has_changes/detection_rules/scanner]   💬  ::debug::Dir names include file patterns: []
   [has_changes/detection_rules/scanner]   💬  ::debug::Unmerged files: {"paths":"","count":"0"}
   [has_changes/detection_rules/scanner]   💬  ::debug::Dir names include file patterns: []
   [has_changes/detection_rules/scanner]   💬  ::debug::Unknown files: {"paths":"","count":"0"}
   [has_changes/detection_rules/scanner]   💬  ::debug::Dir names include file patterns: []
   [has_changes/detection_rules/scanner]   💬  ::debug::All changed and modified files: {"paths":".github/workflows/test-python.yml","count":"1"}
   [has_changes/detection_rules/scanner]   💬  ::debug::Dir names include file patterns: []
   [has_changes/detection_rules/scanner]   💬  ::debug::All changed files: {"paths":".github/workflows/test-python.yml","count":"1"}
   [has_changes/detection_rules/scanner]   💬  ::debug::Dir names include file patterns: []
   [has_changes/detection_rules/scanner]   💬  ::debug::All other changed files: {"paths":".github/workflows/test-python.yml","count":"1"}
   [has_changes/detection_rules/scanner]   💬  ::debug::other_changed_files: []
   [has_changes/detection_rules/scanner]   💬  ::debug::Dir names include file patterns: []
   [has_changes/detection_rules/scanner]   💬  ::debug::All modified files: {"paths":".github/workflows/test-python.yml","count":"1"}
   [has_changes/detection_rules/scanner]   💬  ::debug::Dir names include file patterns: []
   [has_changes/detection_rules/scanner]   💬  ::debug::other_modified_files: []
   [has_changes/detection_rules/scanner]   💬  ::debug::Dir names include file patterns: []
   [has_changes/detection_rules/scanner]   💬  ::debug::Deleted files: {"paths":"","count":"0"}
   [has_changes/detection_rules/scanner]   💬  ::debug::Dir names include file patterns: []
   [has_changes/detection_rules/scanner]   💬  ::debug::other_deleted_files: []
   | All Done!
   [has_changes/detection_rules/scanner]   ❓  ::endgroup::
   [has_changes/detection_rules/scanner]   ✅  Success - Main Detect if any files have changed
   [has_changes/detection_rules/scanner]   ⚙  ::set-output:: all_modified_files_count=1
   [has_changes/detection_rules/scanner]   ⚙  ::set-output:: any_modified=true
   [has_changes/detection_rules/scanner]   ⚙  ::set-output:: added_files_count=0
   [has_changes/detection_rules/scanner]   ⚙  ::set-output:: modified_files_count=1
   [has_changes/detection_rules/scanner]   ⚙  ::set-output:: only_changed=true
   [has_changes/detection_rules/scanner]   ⚙  ::set-output:: other_changed_files_count=0
   [has_changes/detection_rules/scanner]   ⚙  ::set-output:: all_modified_files=.github/workflows/test-python.yml
   [has_changes/detection_rules/scanner]   ⚙  ::set-output:: deleted_files_count=0
   [has_changes/detection_rules/scanner]   ⚙  ::set-output:: copied_files=
   [has_changes/detection_rules/scanner]   ⚙  ::set-output:: renamed_files=
   [has_changes/detection_rules/scanner]   ⚙  ::set-output:: all_changed_files_count=1
   [has_changes/detection_rules/scanner]   ⚙  ::set-output:: unknown_files=
   [has_changes/detection_rules/scanner]   ⚙  ::set-output:: other_modified_files=
   [has_changes/detection_rules/scanner]   ⚙  ::set-output:: unmerged_files=
   [has_changes/detection_rules/scanner]   ⚙  ::set-output:: all_changed_and_modified_files=.github/workflows/test-python.yml
   [has_changes/detection_rules/scanner]   ⚙  ::set-output:: other_deleted_files=
   [has_changes/detection_rules/scanner]   ⚙  ::set-output:: unmerged_files_count=0
   [has_changes/detection_rules/scanner]   ⚙  ::set-output:: only_modified=true
   [has_changes/detection_rules/scanner]   ⚙  ::set-output:: any_deleted=false
   [has_changes/detection_rules/scanner]   ⚙  ::set-output:: only_deleted=false
   [has_changes/detection_rules/scanner]   ⚙  ::set-output:: other_deleted_files_count=0
   [has_changes/detection_rules/scanner]   ⚙  ::set-output:: modified_files=.github/workflows/test-python.yml
   [has_changes/detection_rules/scanner]   ⚙  ::set-output:: unknown_files_count=0
   [has_changes/detection_rules/scanner]   ⚙  ::set-output:: other_changed_files=
   [has_changes/detection_rules/scanner]   ⚙  ::set-output:: copied_files_count=0
   [has_changes/detection_rules/scanner]   ⚙  ::set-output:: renamed_files_count=0
   [has_changes/detection_rules/scanner]   ⚙  ::set-output:: other_modified_files_count=0
   [has_changes/detection_rules/scanner]   ⚙  ::set-output:: all_changed_and_modified_files_count=1
   [has_changes/detection_rules/scanner]   ⚙  ::set-output:: all_changed_files=.github/workflows/test-python.yml
   [has_changes/detection_rules/scanner]   ⚙  ::set-output:: any_changed=true
   [has_changes/detection_rules/scanner]   ⚙  ::set-output:: deleted_files=
   [has_changes/detection_rules/scanner]   ⚙  ::set-output:: added_files=
   [has_changes/detection_rules/scanner]   ⚙  ::set-output:: type_changed_files=
   [has_changes/detection_rules/scanner]   ⚙  ::set-output:: type_changed_files_count=0
   [has_changes/detection_rules/scanner] Cleaning up container for job scanner
   [has_changes/detection_rules/scanner] 🏁  Job succeeded
   [test_python/test_python-2] 🚀  Start image=catthehacker/ubuntu:act-latest
   [test_python/test_python-4] 🚀  Start image=catthehacker/ubuntu:act-latest
   [test_python/test_python-1] 🚀  Start image=catthehacker/ubuntu:act-latest
   [test_python/test_python-3] 🚀  Start image=catthehacker/ubuntu:act-latest
   [test_python/test_python-1]   🐳  docker pull image=catthehacker/ubuntu:act-latest platform=linux/amd64 username= forcePull=true
   [test_python/test_python-4]   🐳  docker pull image=catthehacker/ubuntu:act-latest platform=linux/amd64 username= forcePull=true
   [test_python/test_python-3]   🐳  docker pull image=catthehacker/ubuntu:act-latest platform=linux/amd64 username= forcePull=true
   [test_python/test_python-2]   🐳  docker pull image=catthehacker/ubuntu:act-latest platform=linux/amd64 username= forcePull=true
   [test_python/test_python-3] using DockerAuthConfig authentication for docker pull
   [test_python/test_python-4] using DockerAuthConfig authentication for docker pull
   [test_python/test_python-1] using DockerAuthConfig authentication for docker pull
   [test_python/test_python-2] using DockerAuthConfig authentication for docker pull
   [test_python/test_python-4]   🐳  docker create image=catthehacker/ubuntu:act-latest platform=linux/amd64 entrypoint=["tail" "-f" "/dev/null"] cmd=[] network="host"
   [test_python/test_python-4]   🐳  docker run image=catthehacker/ubuntu:act-latest platform=linux/amd64 entrypoint=["tail" "-f" "/dev/null"] cmd=[] network="host"
   [test_python/test_python-2]   🐳  docker create image=catthehacker/ubuntu:act-latest platform=linux/amd64 entrypoint=["tail" "-f" "/dev/null"] cmd=[] network="host"
   [test_python/test_python-1]   🐳  docker create image=catthehacker/ubuntu:act-latest platform=linux/amd64 entrypoint=["tail" "-f" "/dev/null"] cmd=[] network="host"
   [test_python/test_python-3]   🐳  docker create image=catthehacker/ubuntu:act-latest platform=linux/amd64 entrypoint=["tail" "-f" "/dev/null"] cmd=[] network="host"
   [test_python/test_python-4]   ☁  git clone 'https://github.com/actions/setup-python' # ref=v5
   [test_python/test_python-1]   🐳  docker run image=catthehacker/ubuntu:act-latest platform=linux/amd64 entrypoint=["tail" "-f" "/dev/null"] cmd=[] network="host"
   [test_python/test_python-2]   🐳  docker run image=catthehacker/ubuntu:act-latest platform=linux/amd64 entrypoint=["tail" "-f" "/dev/null"] cmd=[] network="host"
   [test_python/test_python-3]   🐳  docker run image=catthehacker/ubuntu:act-latest platform=linux/amd64 entrypoint=["tail" "-f" "/dev/null"] cmd=[] network="host"
   [test_python/test_python-2]   ☁  git clone 'https://github.com/actions/setup-python' # ref=v5
   [test_python/test_python-1]   ☁  git clone 'https://github.com/actions/setup-python' # ref=v5
   [test_python/test_python-3]   ☁  git clone 'https://github.com/actions/setup-python' # ref=v5
   [test_python/test_python-4] Non-terminating error while running 'git clone': some refs were not updated
   [test_python/test_python-4] 🧪  Matrix: map[python-version:3.12]
   [test_python/test_python-4] ⭐ Run Main SETUP - Checkout
   [test_python/test_python-4]   🐳  docker cp src=/Users/joe.barnett/company/code/cloudzero-charts-jb/. dst=/Users/joe.barnett/company/code/cloudzero-charts-jb
   [test_python/test_python-4]   ✅  Success - Main SETUP - Checkout
   [test_python/test_python-4] ⭐ Run Main SETUP - Python 3.12
   [test_python/test_python-4]   🐳  docker cp src=/Users/joe.barnett/.cache/act/actions-setup-python@v5/ dst=/var/run/act/actions/actions-setup-python@v5/
   [test_python/test_python-4]   🐳  docker exec cmd=[node /var/run/act/actions/actions-setup-python@v5/dist/setup/index.js] user= workdir=
   [test_python/test_python-2] Non-terminating error while running 'git clone': some refs were not updated
   [test_python/test_python-2] 🧪  Matrix: map[python-version:3.10]
   [test_python/test_python-2] ⭐ Run Main SETUP - Checkout
   [test_python/test_python-2]   🐳  docker cp src=/Users/joe.barnett/company/code/cloudzero-charts-jb/. dst=/Users/joe.barnett/company/code/cloudzero-charts-jb
   [test_python/test_python-2]   ✅  Success - Main SETUP - Checkout
   [test_python/test_python-2] ⭐ Run Main SETUP - Python 3.10
   [test_python/test_python-2]   🐳  docker cp src=/Users/joe.barnett/.cache/act/actions-setup-python@v5/ dst=/var/run/act/actions/actions-setup-python@v5/
   [test_python/test_python-4]   💬  ::debug::Python is expected to be installed into /opt/hostedtoolcache
   [test_python/test_python-4]   ❓  ::group::Installed versions
   [test_python/test_python-4]   💬  ::debug::Semantic version spec of 3.12 is 3.12
   [test_python/test_python-4]   💬  ::debug::isExplicit: 
   [test_python/test_python-4]   💬  ::debug::explicit? false
   [test_python/test_python-4]   💬  ::debug::isExplicit: 3.10.14
   [test_python/test_python-4]   💬  ::debug::explicit? true
   [test_python/test_python-4]   💬  ::debug::isExplicit: 3.12.4
   [test_python/test_python-4]   💬  ::debug::explicit? true
   [test_python/test_python-4]   💬  ::debug::isExplicit: 3.8.18
   [test_python/test_python-4]   💬  ::debug::explicit? true
   [test_python/test_python-4]   💬  ::debug::isExplicit: 3.9.19
   [test_python/test_python-4]   💬  ::debug::explicit? true
   [test_python/test_python-4]   💬  ::debug::evaluating 4 versions
   [test_python/test_python-4]   💬  ::debug::matched: 3.12.4
   [test_python/test_python-4]   💬  ::debug::checking cache: /opt/hostedtoolcache/Python/3.12.4/x64
   [test_python/test_python-4]   💬  ::debug::Found tool in cache Python 3.12.4 x64
   | Successfully set up CPython (3.12.4)
   [test_python/test_python-4]   ❓  ::endgroup::
   [test_python/test_python-4]   ❓ add-matcher /run/act/actions/actions-setup-python@v5/.github/python.json
   [test_python/test_python-2]   🐳  docker exec cmd=[node /var/run/act/actions/actions-setup-python@v5/dist/setup/index.js] user= workdir=
   [test_python/test_python-1] Non-terminating error while running 'git clone': some refs were not updated
   [test_python/test_python-1] 🧪  Matrix: map[python-version:3.9]
   [test_python/test_python-4]   ✅  Success - Main SETUP - Python 3.12
   [test_python/test_python-4]   ⚙  ::set-env:: pythonLocation=/opt/hostedtoolcache/Python/3.12.4/x64
   [test_python/test_python-4]   ⚙  ::set-env:: PKG_CONFIG_PATH=/opt/hostedtoolcache/Python/3.12.4/x64/lib/pkgconfig
   [test_python/test_python-4]   ⚙  ::set-env:: Python_ROOT_DIR=/opt/hostedtoolcache/Python/3.12.4/x64
   [test_python/test_python-4]   ⚙  ::set-env:: Python2_ROOT_DIR=/opt/hostedtoolcache/Python/3.12.4/x64
   [test_python/test_python-4]   ⚙  ::set-env:: Python3_ROOT_DIR=/opt/hostedtoolcache/Python/3.12.4/x64
   [test_python/test_python-4]   ⚙  ::set-env:: LD_LIBRARY_PATH=/opt/hostedtoolcache/Python/3.12.4/x64/lib
   [test_python/test_python-4]   ⚙  ::set-output:: python-version=3.12.4
   [test_python/test_python-4]   ⚙  ::set-output:: python-path=/opt/hostedtoolcache/Python/3.12.4/x64/bin/python
   [test_python/test_python-4]   ⚙  ::add-path:: /opt/hostedtoolcache/Python/3.12.4/x64
   [test_python/test_python-4]   ⚙  ::add-path:: /opt/hostedtoolcache/Python/3.12.4/x64/bin
   [test_python/test_python-1] ⭐ Run Main SETUP - Checkout
   [test_python/test_python-1]   🐳  docker cp src=/Users/joe.barnett/company/code/cloudzero-charts-jb/. dst=/Users/joe.barnett/company/code/cloudzero-charts-jb
   [test_python/test_python-4] ⭐ Run Main SETUP - Display Python version
   [test_python/test_python-1]   ✅  Success - Main SETUP - Checkout
   [test_python/test_python-4]   🐳  docker exec cmd=[bash --noprofile --norc -e -o pipefail /var/run/act/workflow/2] user= workdir=
   [test_python/test_python-1] ⭐ Run Main SETUP - Python 3.9
   [test_python/test_python-1]   🐳  docker cp src=/Users/joe.barnett/.cache/act/actions-setup-python@v5/ dst=/var/run/act/actions/actions-setup-python@v5/
   | 3.12.4 (main, Jun 11 2024, 16:51:22) [GCC 11.4.0]
   [test_python/test_python-4]   ✅  Success - Main SETUP - Display Python version
   [test_python/test_python-4] ⭐ Run Main TEST - Run checks
   [test_python/test_python-4]   🐳  docker exec cmd=[bash --noprofile --norc -e -o pipefail /var/run/act/workflow/3] user= workdir=
   [test_python/test_python-1]   🐳  docker exec cmd=[node /var/run/act/actions/actions-setup-python@v5/dist/setup/index.js] user= workdir=
   [test_python/test_python-3] Non-terminating error while running 'git clone': some refs were not updated
   [test_python/test_python-3] 🧪  Matrix: map[python-version:3.11]
   [test_python/test_python-3] ⭐ Run Main SETUP - Checkout
   [test_python/test_python-3]   🐳  docker cp src=/Users/joe.barnett/company/code/cloudzero-charts-jb/. dst=/Users/joe.barnett/company/code/cloudzero-charts-jb
   [test_python/test_python-2]   💬  ::debug::Python is expected to be installed into /opt/hostedtoolcache
   [test_python/test_python-2]   ❓  ::group::Installed versions
   [test_python/test_python-2]   💬  ::debug::Semantic version spec of 3.10 is 3.10
   [test_python/test_python-2]   💬  ::debug::isExplicit: 
   [test_python/test_python-2]   💬  ::debug::explicit? false
   [test_python/test_python-2]   💬  ::debug::isExplicit: 3.10.14
   [test_python/test_python-2]   💬  ::debug::explicit? true
   [test_python/test_python-2]   💬  ::debug::isExplicit: 3.12.4
   [test_python/test_python-2]   💬  ::debug::explicit? true
   [test_python/test_python-2]   💬  ::debug::isExplicit: 3.8.18
   [test_python/test_python-2]   💬  ::debug::explicit? true
   [test_python/test_python-2]   💬  ::debug::isExplicit: 3.9.19
   [test_python/test_python-2]   💬  ::debug::explicit? true
   [test_python/test_python-2]   💬  ::debug::evaluating 4 versions
   [test_python/test_python-2]   💬  ::debug::matched: 3.10.14
   [test_python/test_python-2]   💬  ::debug::checking cache: /opt/hostedtoolcache/Python/3.10.14/x64
   [test_python/test_python-2]   💬  ::debug::Found tool in cache Python 3.10.14 x64
   | Successfully set up CPython (3.10.14)
   [test_python/test_python-2]   ❓  ::endgroup::
   [test_python/test_python-2]   ❓ add-matcher /run/act/actions/actions-setup-python@v5/.github/python.json
   [test_python/test_python-3]   ✅  Success - Main SETUP - Checkout
   [test_python/test_python-3] ⭐ Run Main SETUP - Python 3.11
   [test_python/test_python-3]   🐳  docker cp src=/Users/joe.barnett/.cache/act/actions-setup-python@v5/ dst=/var/run/act/actions/actions-setup-python@v5/
   [test_python/test_python-2]   ✅  Success - Main SETUP - Python 3.10
   [test_python/test_python-2]   ⚙  ::set-env:: pythonLocation=/opt/hostedtoolcache/Python/3.10.14/x64
   [test_python/test_python-2]   ⚙  ::set-env:: PKG_CONFIG_PATH=/opt/hostedtoolcache/Python/3.10.14/x64/lib/pkgconfig
   [test_python/test_python-2]   ⚙  ::set-env:: Python_ROOT_DIR=/opt/hostedtoolcache/Python/3.10.14/x64
   [test_python/test_python-2]   ⚙  ::set-env:: Python2_ROOT_DIR=/opt/hostedtoolcache/Python/3.10.14/x64
   [test_python/test_python-2]   ⚙  ::set-env:: Python3_ROOT_DIR=/opt/hostedtoolcache/Python/3.10.14/x64
   [test_python/test_python-2]   ⚙  ::set-env:: LD_LIBRARY_PATH=/opt/hostedtoolcache/Python/3.10.14/x64/lib
   [test_python/test_python-2]   ⚙  ::set-output:: python-version=3.10.14
   [test_python/test_python-2]   ⚙  ::set-output:: python-path=/opt/hostedtoolcache/Python/3.10.14/x64/bin/python
   [test_python/test_python-2]   ⚙  ::add-path:: /opt/hostedtoolcache/Python/3.10.14/x64
   [test_python/test_python-2]   ⚙  ::add-path:: /opt/hostedtoolcache/Python/3.10.14/x64/bin
   [test_python/test_python-2] ⭐ Run Main SETUP - Display Python version
   [test_python/test_python-2]   🐳  docker exec cmd=[bash --noprofile --norc -e -o pipefail /var/run/act/workflow/2] user= workdir=
   | 3.10.14 (main, Jun 20 2024, 15:20:03) [GCC 11.4.0]
   [test_python/test_python-2]   ✅  Success - Main SETUP - Display Python version
   [test_python/test_python-3]   🐳  docker exec cmd=[node /var/run/act/actions/actions-setup-python@v5/dist/setup/index.js] user= workdir=
   [test_python/test_python-2] ⭐ Run Main TEST - Run checks
   [test_python/test_python-1]   💬  ::debug::Python is expected to be installed into /opt/hostedtoolcache
   [test_python/test_python-1]   ❓  ::group::Installed versions
   [test_python/test_python-1]   💬  ::debug::Semantic version spec of 3.9 is 3.9
   [test_python/test_python-1]   💬  ::debug::isExplicit: 
   [test_python/test_python-1]   💬  ::debug::explicit? false
   [test_python/test_python-1]   💬  ::debug::isExplicit: 3.10.14
   [test_python/test_python-1]   💬  ::debug::explicit? true
   [test_python/test_python-1]   💬  ::debug::isExplicit: 3.12.4
   [test_python/test_python-1]   💬  ::debug::explicit? true
   [test_python/test_python-1]   💬  ::debug::isExplicit: 3.8.18
   [test_python/test_python-1]   💬  ::debug::explicit? true
   [test_python/test_python-1]   💬  ::debug::isExplicit: 3.9.19
   [test_python/test_python-1]   💬  ::debug::explicit? true
   [test_python/test_python-1]   💬  ::debug::evaluating 4 versions
   [test_python/test_python-1]   💬  ::debug::matched: 3.9.19
   [test_python/test_python-1]   💬  ::debug::checking cache: /opt/hostedtoolcache/Python/3.9.19/x64
   [test_python/test_python-1]   💬  ::debug::Found tool in cache Python 3.9.19 x64
   [test_python/test_python-2]   🐳  docker exec cmd=[bash --noprofile --norc -e -o pipefail /var/run/act/workflow/3] user= workdir=
   | Successfully set up CPython (3.9.19)
   [test_python/test_python-1]   ❓  ::endgroup::
   [test_python/test_python-1]   ❓ add-matcher /run/act/actions/actions-setup-python@v5/.github/python.json
   [test_python/test_python-1]   ✅  Success - Main SETUP - Python 3.9
   [test_python/test_python-1]   ⚙  ::set-env:: pythonLocation=/opt/hostedtoolcache/Python/3.9.19/x64
   [test_python/test_python-1]   ⚙  ::set-env:: PKG_CONFIG_PATH=/opt/hostedtoolcache/Python/3.9.19/x64/lib/pkgconfig
   [test_python/test_python-1]   ⚙  ::set-env:: Python_ROOT_DIR=/opt/hostedtoolcache/Python/3.9.19/x64
   [test_python/test_python-1]   ⚙  ::set-env:: Python2_ROOT_DIR=/opt/hostedtoolcache/Python/3.9.19/x64
   [test_python/test_python-1]   ⚙  ::set-env:: Python3_ROOT_DIR=/opt/hostedtoolcache/Python/3.9.19/x64
   [test_python/test_python-1]   ⚙  ::set-env:: LD_LIBRARY_PATH=/opt/hostedtoolcache/Python/3.9.19/x64/lib
   [test_python/test_python-1]   ⚙  ::set-output:: python-version=3.9.19
   [test_python/test_python-1]   ⚙  ::set-output:: python-path=/opt/hostedtoolcache/Python/3.9.19/x64/bin/python
   [test_python/test_python-1]   ⚙  ::add-path:: /opt/hostedtoolcache/Python/3.9.19/x64
   [test_python/test_python-1]   ⚙  ::add-path:: /opt/hostedtoolcache/Python/3.9.19/x64/bin
   [test_python/test_python-1] ⭐ Run Main SETUP - Display Python version
   [test_python/test_python-1]   🐳  docker exec cmd=[bash --noprofile --norc -e -o pipefail /var/run/act/workflow/2] user= workdir=
   | 3.9.19 (main, Jun 20 2024, 15:12:30) 
   | [GCC 11.4.0]
   [test_python/test_python-1]   ✅  Success - Main SETUP - Display Python version
   [test_python/test_python-1] ⭐ Run Main TEST - Run checks
   [test_python/test_python-1]   🐳  docker exec cmd=[bash --noprofile --norc -e -o pipefail /var/run/act/workflow/3] user= workdir=
   [test_python/test_python-3]   💬  ::debug::Python is expected to be installed into /opt/hostedtoolcache
   [test_python/test_python-3]   ❓  ::group::Installed versions
   [test_python/test_python-3]   💬  ::debug::Semantic version spec of 3.11 is 3.11
   [test_python/test_python-3]   💬  ::debug::isExplicit: 
   [test_python/test_python-3]   💬  ::debug::explicit? false
   [test_python/test_python-3]   💬  ::debug::isExplicit: 3.10.14
   [test_python/test_python-3]   💬  ::debug::explicit? true
   [test_python/test_python-3]   💬  ::debug::isExplicit: 3.12.4
   [test_python/test_python-3]   💬  ::debug::explicit? true
   [test_python/test_python-3]   💬  ::debug::isExplicit: 3.8.18
   [test_python/test_python-3]   💬  ::debug::explicit? true
   [test_python/test_python-3]   💬  ::debug::isExplicit: 3.9.19
   [test_python/test_python-3]   💬  ::debug::explicit? true
   [test_python/test_python-3]   💬  ::debug::evaluating 4 versions
   [test_python/test_python-3]   💬  ::debug::match not found
   | Version 3.11 was not found in the local cache
   [test_python/test_python-3]   💬  ::debug::Getting manifest from actions/python-versions@main
   [test_python/test_python-3]   💬  ::debug::check 3.13.0-beta.2 satisfies 3.11
   [test_python/test_python-3]   💬  ::debug::check 3.13.0-beta.1 satisfies 3.11
   [test_python/test_python-3]   💬  ::debug::check 3.13.0-alpha.6 satisfies 3.11
   [test_python/test_python-3]   💬  ::debug::check 3.13.0-alpha.5 satisfies 3.11
   [test_python/test_python-3]   💬  ::debug::check 3.13.0-alpha.4 satisfies 3.11
   [test_python/test_python-3]   💬  ::debug::check 3.13.0-alpha.3 satisfies 3.11
   [test_python/test_python-3]   💬  ::debug::check 3.13.0-alpha.2 satisfies 3.11
   [test_python/test_python-3]   💬  ::debug::check 3.13.0-alpha.1 satisfies 3.11
   [test_python/test_python-3]   💬  ::debug::check 3.12.4 satisfies 3.11
   [test_python/test_python-3]   💬  ::debug::check 3.12.3 satisfies 3.11
   [test_python/test_python-3]   💬  ::debug::check 3.12.2 satisfies 3.11
   [test_python/test_python-3]   💬  ::debug::check 3.12.1 satisfies 3.11
   [test_python/test_python-3]   💬  ::debug::check 3.12.0 satisfies 3.11
   [test_python/test_python-3]   💬  ::debug::check 3.12.0-rc.3 satisfies 3.11
   [test_python/test_python-3]   💬  ::debug::check 3.12.0-rc.2 satisfies 3.11
   [test_python/test_python-3]   💬  ::debug::check 3.12.0-rc.1 satisfies 3.11
   [test_python/test_python-3]   💬  ::debug::check 3.12.0-beta.4 satisfies 3.11
   [test_python/test_python-3]   💬  ::debug::check 3.12.0-beta.3 satisfies 3.11
   [test_python/test_python-3]   💬  ::debug::check 3.12.0-beta.2 satisfies 3.11
   [test_python/test_python-3]   💬  ::debug::check 3.12.0-beta.1 satisfies 3.11
   [test_python/test_python-3]   💬  ::debug::check 3.12.0-alpha.7 satisfies 3.11
   [test_python/test_python-3]   💬  ::debug::check 3.12.0-alpha.6 satisfies 3.11
   [test_python/test_python-3]   💬  ::debug::check 3.12.0-alpha.5 satisfies 3.11
   [test_python/test_python-3]   💬  ::debug::check 3.12.0-alpha.4 satisfies 3.11
   [test_python/test_python-3]   💬  ::debug::check 3.12.0-alpha.3 satisfies 3.11
   [test_python/test_python-3]   💬  ::debug::check 3.12.0-alpha.2 satisfies 3.11
   [test_python/test_python-3]   💬  ::debug::check 3.12.0-alpha.1 satisfies 3.11
   [test_python/test_python-3]   💬  ::debug::check 3.11.9 satisfies 3.11
   [test_python/test_python-3]   💬  ::debug::arm64===x64 && darwin===linux
   [test_python/test_python-3]   💬  ::debug::x64===x64 && darwin===linux
   [test_python/test_python-3]   💬  ::debug::x64===x64 && linux===linux
   [test_python/test_python-3]   💬  ::debug::arm64===x64 && linux===linux
   [test_python/test_python-3]   💬  ::debug::x64===x64 && linux===linux
   [test_python/test_python-3]   💬  ::debug::matched 3.11.9
   | Version 3.11 is available for downloading
   | Download from "https://github.com/actions/python-versions/releases/download/3.11.9-9600593881/python-3.11.9-linux-22.04-x64.tar.gz"
   [test_python/test_python-3]   💬  ::debug::Downloading https://github.com/actions/python-versions/releases/download/3.11.9-9600593881/python-3.11.9-linux-22.04-x64.tar.gz
   [test_python/test_python-3]   💬  ::debug::Destination /tmp/3361db74-2abe-49f2-87b4-3a741ba24941
   [test_python/test_python-3]   💬  ::debug::download complete
   | Extract downloaded archive
   [test_python/test_python-3]   💬  ::debug::Checking tar --version
   [test_python/test_python-3]   💬  ::debug::tar (GNU tar) 1.34%0ACopyright (C) 2021 Free Software Foundation, Inc.%0ALicense GPLv3+: GNU GPL version 3 or later <https://gnu.org/licenses/gpl.html>.%0AThis is free software: you are free to change and redistribute it.%0AThere is NO WARRANTY, to the extent permitted by law.%0A%0AWritten by John Gilmore and Jay Fenlason.
   | [command]/usr/bin/tar xz --warning=no-unknown-keyword --overwrite -C /tmp/6c6341a0-99e8-48b7-bf1c-08d0c88539ad -f /tmp/3361db74-2abe-49f2-87b4-3a741ba24941
   | Collecting requests==2.32.3
   | Collecting requests==2.32.3
   | Collecting requests==2.32.3 (from -r src/requirements.txt (line 1))
   |   Downloading requests-2.32.3-py3-none-any.whl (64 kB)
      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 64.9/64.9 kB 6.0 MB/s eta 0:00:00
   |   Downloading requests-2.32.3-py3-none-any.whl (64 kB)
   |   Downloading requests-2.32.3-py3-none-any.whl.metadata (4.6 kB)
      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 64.9/64.9 kB 6.5 MB/s eta 0:00:00
   | Collecting certifi>=2017.4.17
   |   Downloading certifi-2024.6.2-py3-none-any.whl (164 kB)
      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 164.4/164.4 kB 23.2 MB/s eta 0:00:00
   | Collecting charset-normalizer<4,>=2 (from requests==2.32.3->-r src/requirements.txt (line 1))
   |   Downloading charset_normalizer-3.3.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (33 kB)
   | Collecting charset-normalizer<4,>=2
   |   Downloading charset_normalizer-3.3.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (142 kB)
      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 142.1/142.1 kB 4.7 MB/s eta 0:00:00
   | Collecting idna<4,>=2.5 (from requests==2.32.3->-r src/requirements.txt (line 1))
   | Collecting charset-normalizer<4,>=2
   |   Downloading idna-3.7-py3-none-any.whl.metadata (9.9 kB)
   |   Downloading charset_normalizer-3.3.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (142 kB)
      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 142.3/142.3 kB 33.1 MB/s eta 0:00:00
   | Collecting idna<4,>=2.5
   |   Downloading idna-3.7-py3-none-any.whl (66 kB)
   | Collecting idna<4,>=2.5
      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 66.8/66.8 kB 10.4 MB/s eta 0:00:00
   |   Downloading idna-3.7-py3-none-any.whl (66 kB)
      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 66.8/66.8 kB 19.2 MB/s eta 0:00:00
   | Collecting urllib3<3,>=1.21.1 (from requests==2.32.3->-r src/requirements.txt (line 1))
   | Collecting certifi>=2017.4.17
   |   Downloading urllib3-2.2.2-py3-none-any.whl.metadata (6.4 kB)
   |   Downloading certifi-2024.6.2-py3-none-any.whl (164 kB)
      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 164.4/164.4 kB 24.2 MB/s eta 0:00:00
   | Collecting certifi>=2017.4.17 (from requests==2.32.3->-r src/requirements.txt (line 1))
   | Collecting urllib3<3,>=1.21.1
   |   Downloading certifi-2024.6.2-py3-none-any.whl.metadata (2.2 kB)
   |   Downloading urllib3-2.2.2-py3-none-any.whl (121 kB)
      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 121.4/121.4 kB 29.8 MB/s eta 0:00:00
   | Installing collected packages: urllib3, idna, charset-normalizer, certifi, requests
   | Downloading requests-2.32.3-py3-none-any.whl (64 kB)
   | Collecting urllib3<3,>=1.21.1
      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 64.9/64.9 kB 22.5 MB/s eta 0:00:00
   |   Downloading urllib3-2.2.2-py3-none-any.whl (121 kB)
   | Downloading certifi-2024.6.2-py3-none-any.whl (164 kB)
      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 121.4/121.4 kB 26.0 MB/s eta 0:00:00
      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 164.4/164.4 kB 13.9 MB/s eta 0:00:00
   | Downloading charset_normalizer-3.3.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (141 kB)
      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 141.9/141.9 kB 13.1 MB/s eta 0:00:00
   | Downloading idna-3.7-py3-none-any.whl (66 kB)
      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 66.8/66.8 kB 10.9 MB/s eta 0:00:00
   | Downloading urllib3-2.2.2-py3-none-any.whl (121 kB)
   | Installing collected packages: urllib3, idna, charset-normalizer, certifi, requests
      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 121.4/121.4 kB 12.0 MB/s eta 0:00:00
   | Installing collected packages: urllib3, idna, charset-normalizer, certifi, requests
   | Successfully installed certifi-2024.6.2 charset-normalizer-3.3.2 idna-3.7 requests-2.32.3 urllib3-2.2.2
   | Successfully installed certifi-2024.6.2 charset-normalizer-3.3.2 idna-3.7 requests-2.32.3 urllib3-2.2.2
   | Successfully installed certifi-2024.6.2 charset-normalizer-3.3.2 idna-3.7 requests-2.32.3 urllib3-2.2.2
   | 
   | [notice] A new release of pip is available: 23.0.1 -> 24.1
   | [notice] To update, run: pip install --upgrade pip
   | 
   | [notice] A new release of pip is available: 23.0.1 -> 24.1
   | [notice] To update, run: pip install --upgrade pip
   | 
   | [notice] A new release of pip is available: 24.0 -> 24.1
   | [notice] To update, run: pip install --upgrade pip
   | Execute installation script
   | Check if Python hostedtoolcache folder exist...
   | Create Python 3.11.9 folder
   | Copy Python binaries to hostedtoolcache folder
   | Collecting black==22.3.0 (from -r tests/requirements.txt (line 6))
   | Collecting black==22.3.0
   | Create additional symlinks (Required for the UsePythonVersion Azure Pipelines task and the setup-python GitHub Action)
   | Upgrading pip...
   |   Downloading black-22.3.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (1.5 MB)
   |   Downloading black-22.3.0-py3-none-any.whl.metadata (45 kB)
      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 45.6/45.6 kB 1.2 MB/s eta 0:00:00
      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.5/1.5 MB 18.9 MB/s eta 0:00:00
   | Collecting click==8.1.3 (from -r tests/requirements.txt (line 7))
   |   Downloading click-8.1.3-py3-none-any.whl.metadata (3.2 kB)
   | Collecting black==22.3.0
   | Collecting click==8.1.3
   |   Downloading click-8.1.3-py3-none-any.whl (96 kB)
      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 96.6/96.6 kB 21.8 MB/s eta 0:00:00
   | Collecting pytest==7.1.3 (from -r tests/requirements.txt (line 8))
   |   Downloading black-22.3.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (1.5 MB)
   |   Downloading pytest-7.1.3-py3-none-any.whl.metadata (7.7 kB)
   | Collecting pytest==7.1.3
   | Collecting pytest-cov==4.0.0 (from -r tests/requirements.txt (line 9))
   |   Downloading pytest-7.1.3-py3-none-any.whl (298 kB)
      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.5/1.5 MB 22.7 MB/s eta 0:00:00
      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 298.2/298.2 kB 23.9 MB/s eta 0:00:00
   |   Downloading pytest_cov-4.0.0-py3-none-any.whl.metadata (25 kB)
   | Collecting click==8.1.3
   | Collecting pytest-cov==4.0.0
   |   Downloading click-8.1.3-py3-none-any.whl (96 kB)
   |   Downloading pytest_cov-4.0.0-py3-none-any.whl (21 kB)
      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 96.6/96.6 kB 11.6 MB/s eta 0:00:00
   | Collecting pytest-mock
   | Collecting pytest==7.1.3
   |   Downloading pytest_mock-3.14.0-py3-none-any.whl (9.9 kB)
   | Collecting pytest-mock (from -r tests/requirements.txt (line 10))
   |   Downloading pytest_mock-3.14.0-py3-none-any.whl.metadata (3.8 kB)
   |   Downloading pytest-7.1.3-py3-none-any.whl (298 kB)
      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 298.2/298.2 kB 23.7 MB/s eta 0:00:00
   | Collecting pytest-cov==4.0.0
   |   Downloading pytest_cov-4.0.0-py3-none-any.whl (21 kB)
   | Collecting pytest-mock
   |   Downloading pytest_mock-3.14.0-py3-none-any.whl (9.9 kB)
   | Collecting ruff==0.0.284 (from -r tests/requirements.txt (line 12))
   |   Downloading ruff-0.0.284-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (21 kB)
   | Collecting platformdirs>=2 (from black==22.3.0->-r tests/requirements.txt (line 6))
   | Collecting ruff==0.0.284
   |   Downloading platformdirs-4.2.2-py3-none-any.whl.metadata (11 kB)
   |   Downloading ruff-0.0.284-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (5.7 MB)
   | Collecting pathspec>=0.9.0 (from black==22.3.0->-r tests/requirements.txt (line 6))
   |   Downloading pathspec-0.12.1-py3-none-any.whl.metadata (21 kB)
      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 5.7/5.7 MB 44.1 MB/s eta 0:00:00
   | Collecting mypy-extensions>=0.4.3 (from black==22.3.0->-r tests/requirements.txt (line 6))
   |   Downloading mypy_extensions-1.0.0-py3-none-any.whl.metadata (1.1 kB)
   | Collecting pathspec>=0.9.0
   | Collecting ruff==0.0.284
   |   Downloading pathspec-0.12.1-py3-none-any.whl (31 kB)
   | Collecting attrs>=19.2.0 (from pytest==7.1.3->-r tests/requirements.txt (line 8))
   |   Downloading ruff-0.0.284-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (5.7 MB)
   |   Downloading attrs-23.2.0-py3-none-any.whl.metadata (9.5 kB)
   | Collecting platformdirs>=2
   |   Downloading platformdirs-4.2.2-py3-none-any.whl (18 kB)
      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 5.7/5.7 MB 28.8 MB/s eta 0:00:00
   | Collecting iniconfig (from pytest==7.1.3->-r tests/requirements.txt (line 8))
   |   Downloading iniconfig-2.0.0-py3-none-any.whl.metadata (2.6 kB)
   | Collecting mypy-extensions>=0.4.3
   |   Downloading mypy_extensions-1.0.0-py3-none-any.whl (4.7 kB)
   | Collecting mypy-extensions>=0.4.3
   |   Downloading mypy_extensions-1.0.0-py3-none-any.whl (4.7 kB)
   | Collecting packaging (from pytest==7.1.3->-r tests/requirements.txt (line 8))
   |   Downloading packaging-24.1-py3-none-any.whl.metadata (3.2 kB)
   | Collecting typing-extensions>=3.10.0.0
   |   Downloading typing_extensions-4.12.2-py3-none-any.whl (37 kB)
   | Collecting pathspec>=0.9.0
   |   Downloading pathspec-0.12.1-py3-none-any.whl (31 kB)
   | Collecting pluggy<2.0,>=0.12 (from pytest==7.1.3->-r tests/requirements.txt (line 8))
   |   Downloading pluggy-1.5.0-py3-none-any.whl.metadata (4.8 kB)
   | Collecting tomli>=1.1.0
   | Collecting tomli>=1.1.0
   |   Downloading tomli-2.0.1-py3-none-any.whl (12 kB)
   |   Downloading tomli-2.0.1-py3-none-any.whl (12 kB)
   | Collecting py>=1.8.2 (from pytest==7.1.3->-r tests/requirements.txt (line 8))
   |   Downloading py-1.11.0-py2.py3-none-any.whl.metadata (2.8 kB)
   | Collecting platformdirs>=2
   | Collecting packaging
   | Collecting tomli>=1.0.0 (from pytest==7.1.3->-r tests/requirements.txt (line 8))
   |   Downloading platformdirs-4.2.2-py3-none-any.whl (18 kB)
   |   Downloading packaging-24.1-py3-none-any.whl (53 kB)
   |   Downloading tomli-2.0.1-py3-none-any.whl.metadata (8.9 kB)
      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 54.0/54.0 kB 6.0 MB/s eta 0:00:00
   | Collecting pluggy<2.0,>=0.12
   |   Downloading pluggy-1.5.0-py3-none-any.whl (20 kB)
   | Collecting pluggy<2.0,>=0.12
   |   Downloading pluggy-1.5.0-py3-none-any.whl (20 kB)
   | Collecting attrs>=19.2.0
   |   Downloading attrs-23.2.0-py3-none-any.whl (60 kB)
      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 60.8/60.8 kB 5.6 MB/s eta 0:00:00
   | Collecting py>=1.8.2
   |   Downloading py-1.11.0-py2.py3-none-any.whl (98 kB)
      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 98.7/98.7 kB 13.3 MB/s eta 0:00:00
   | Collecting py>=1.8.2
   |   Downloading py-1.11.0-py2.py3-none-any.whl (98 kB)
   | Collecting attrs>=19.2.0
      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 98.7/98.7 kB 8.4 MB/s eta 0:00:00
   |   Downloading attrs-23.2.0-py3-none-any.whl (60 kB)
      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 60.8/60.8 kB 9.6 MB/s eta 0:00:00
   | Collecting iniconfig
   | Collecting iniconfig
   |   Downloading iniconfig-2.0.0-py3-none-any.whl (5.9 kB)
   |   Downloading iniconfig-2.0.0-py3-none-any.whl (5.9 kB)
   | Collecting packaging
   |   Downloading packaging-24.1-py3-none-any.whl (53 kB)
      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 54.0/54.0 kB 9.2 MB/s eta 0:00:00
   | Collecting coverage>=5.2.1 (from coverage[toml]>=5.2.1->pytest-cov==4.0.0->-r tests/requirements.txt (line 9))
   |   Downloading coverage-7.5.4-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (8.2 kB)
   | Looking in links: /tmp/tmp1eyg5ehs
   | Requirement already satisfied: setuptools in /opt/hostedtoolcache/Python/3.11.9/x64/lib/python3.11/site-packages (65.5.0)
   | Requirement already satisfied: pip in /opt/hostedtoolcache/Python/3.11.9/x64/lib/python3.11/site-packages (24.0)
   [test_python/test_python-3]   ❗  ::error::WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv
   | Downloading black-22.3.0-py3-none-any.whl (153 kB)
      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 153.9/153.9 kB 18.4 MB/s eta 0:00:00
   | Downloading click-8.1.3-py3-none-any.whl (96 kB)
      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 96.6/96.6 kB 6.0 MB/s eta 0:00:00
   | Downloading pytest-7.1.3-py3-none-any.whl (298 kB)
      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 298.2/298.2 kB 9.2 MB/s eta 0:00:00
   | Downloading pytest_cov-4.0.0-py3-none-any.whl (21 kB)
   | Downloading ruff-0.0.284-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (5.7 MB)
      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 5.7/5.7 MB 24.8 MB/s eta 0:00:00
   | Downloading pytest_mock-3.14.0-py3-none-any.whl (9.9 kB)
   | Downloading attrs-23.2.0-py3-none-any.whl (60 kB)
      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 60.8/60.8 kB 3.7 MB/s eta 0:00:00
   | Downloading coverage-7.5.4-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl (237 kB)
      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 237.9/237.9 kB 9.6 MB/s eta 0:00:00
   | Downloading mypy_extensions-1.0.0-py3-none-any.whl (4.7 kB)
   | Collecting coverage[toml]>=5.2.1
   | Downloading pathspec-0.12.1-py3-none-any.whl (31 kB)
   |   Downloading coverage-7.5.4-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl (233 kB)
      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 233.1/233.1 kB 44.6 MB/s eta 0:00:00
   | Downloading platformdirs-4.2.2-py3-none-any.whl (18 kB)
   | Collecting coverage[toml]>=5.2.1
   | Downloading pluggy-1.5.0-py3-none-any.whl (20 kB)
   |   Downloading coverage-7.5.4-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl (232 kB)
   | Downloading py-1.11.0-py2.py3-none-any.whl (98 kB)
      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 232.7/232.7 kB 20.2 MB/s eta 0:00:00
      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 98.7/98.7 kB 10.9 MB/s eta 0:00:00
   | Downloading tomli-2.0.1-py3-none-any.whl (12 kB)
   | Downloading iniconfig-2.0.0-py3-none-any.whl (5.9 kB)
   | Downloading packaging-24.1-py3-none-any.whl (53 kB)
      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 54.0/54.0 kB 4.4 MB/s eta 0:00:00
   | Installing collected packages: tomli, ruff, py, pluggy, platformdirs, pathspec, packaging, mypy-extensions, iniconfig, coverage, click, attrs, pytest, black, pytest-mock, pytest-cov
   | Installing collected packages: typing-extensions, tomli, ruff, py, pluggy, platformdirs, pathspec, packaging, mypy-extensions, iniconfig, coverage, click, attrs, pytest, black, pytest-mock, pytest-cov
   | Installing collected packages: tomli, ruff, py, pluggy, platformdirs, pathspec, packaging, mypy-extensions, iniconfig, coverage, click, attrs, pytest, black, pytest-mock, pytest-cov
   | Successfully installed attrs-23.2.0 black-22.3.0 click-8.1.3 coverage-7.5.4 iniconfig-2.0.0 mypy-extensions-1.0.0 packaging-24.1 pathspec-0.12.1 platformdirs-4.2.2 pluggy-1.5.0 py-1.11.0 pytest-7.1.3 pytest-cov-4.0.0 pytest-mock-3.14.0 ruff-0.0.284 tomli-2.0.1
   | 
   | [notice] A new release of pip is available: 23.0.1 -> 24.1
   | [notice] To update, run: pip install --upgrade pip
   | Successfully installed attrs-23.2.0 black-22.3.0 click-8.1.3 coverage-7.5.4 iniconfig-2.0.0 mypy-extensions-1.0.0 packaging-24.1 pathspec-0.12.1 platformdirs-4.2.2 pluggy-1.5.0 py-1.11.0 pytest-7.1.3 pytest-cov-4.0.0 pytest-mock-3.14.0 ruff-0.0.284 tomli-2.0.1 typing-extensions-4.12.2
   | 
   | [notice] A new release of pip is available: 23.0.1 -> 24.1
   | [notice] To update, run: pip install --upgrade pip
   | Collecting pip
   | Downloading pip-24.1-py3-none-any.whl.metadata (3.6 kB)
   | Downloading pip-24.1-py3-none-any.whl (1.8 MB)
   | Successfully installed attrs-23.2.0 black-22.3.0 click-8.1.3 coverage-7.5.4 iniconfig-2.0.0 mypy-extensions-1.0.0 packaging-24.1 pathspec-0.12.1 platformdirs-4.2.2 pluggy-1.5.0 py-1.11.0 pytest-7.1.3 pytest-cov-4.0.0 pytest-mock-3.14.0 ruff-0.0.284 tomli-2.0.1
   | 
   | [notice] A new release of pip is available: 24.0 -> 24.1
   | [notice] To update, run: pip install --upgrade pip
   | ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.8/1.8 MB 19.8 MB/s eta 0:00:00
   | 
   | Installing collected packages: pip
   | Attempting uninstall: pip
   | Found existing installation: pip 24.0
   | Uninstalling pip-24.0:
   | Successfully uninstalled pip-24.0
   | All done! ✨ 🍰 ✨
   | 2 files left unchanged.
   | All done! ✨ 🍰 ✨
   | 2 files left unchanged.
   | All done! ✨ 🍰 ✨
   | 2 files left unchanged.
   | Successfully installed pip-24.1
   | Create complete file
   [test_python/test_python-3]   💬  ::debug::isExplicit: 
   [test_python/test_python-3]   💬  ::debug::explicit? false
   [test_python/test_python-3]   💬  ::debug::isExplicit: 3.10.14
   [test_python/test_python-3]   💬  ::debug::explicit? true
   [test_python/test_python-3]   💬  ::debug::isExplicit: 3.11.9
   [test_python/test_python-3]   💬  ::debug::explicit? true
   [test_python/test_python-3]   💬  ::debug::isExplicit: 3.12.4
   [test_python/test_python-3]   💬  ::debug::explicit? true
   [test_python/test_python-3]   💬  ::debug::isExplicit: 3.8.18
   [test_python/test_python-3]   💬  ::debug::explicit? true
   [test_python/test_python-3]   💬  ::debug::isExplicit: 3.9.19
   [test_python/test_python-3]   💬  ::debug::explicit? true
   [test_python/test_python-3]   💬  ::debug::evaluating 5 versions
   [test_python/test_python-3]   💬  ::debug::matched: 3.11.9
   [test_python/test_python-3]   💬  ::debug::checking cache: /opt/hostedtoolcache/Python/3.11.9/x64
   [test_python/test_python-3]   💬  ::debug::Found tool in cache Python 3.11.9 x64
   | Successfully set up CPython (3.11.9)
   [test_python/test_python-3]   ❓  ::endgroup::
   [test_python/test_python-3]   ❓ add-matcher /run/act/actions/actions-setup-python@v5/.github/python.json
   [test_python/test_python-3]   ✅  Success - Main SETUP - Python 3.11
   [test_python/test_python-3]   ⚙  ::set-env:: pythonLocation=/opt/hostedtoolcache/Python/3.11.9/x64
   [test_python/test_python-3]   ⚙  ::set-env:: PKG_CONFIG_PATH=/opt/hostedtoolcache/Python/3.11.9/x64/lib/pkgconfig
   [test_python/test_python-3]   ⚙  ::set-env:: Python_ROOT_DIR=/opt/hostedtoolcache/Python/3.11.9/x64
   [test_python/test_python-3]   ⚙  ::set-env:: Python2_ROOT_DIR=/opt/hostedtoolcache/Python/3.11.9/x64
   [test_python/test_python-3]   ⚙  ::set-env:: Python3_ROOT_DIR=/opt/hostedtoolcache/Python/3.11.9/x64
   [test_python/test_python-3]   ⚙  ::set-env:: LD_LIBRARY_PATH=/opt/hostedtoolcache/Python/3.11.9/x64/lib
   [test_python/test_python-3]   ⚙  ::set-output:: python-version=3.11.9
   [test_python/test_python-3]   ⚙  ::set-output:: python-path=/opt/hostedtoolcache/Python/3.11.9/x64/bin/python
   [test_python/test_python-3]   ⚙  ::add-path:: /opt/hostedtoolcache/Python/3.11.9/x64
   [test_python/test_python-3]   ⚙  ::add-path:: /opt/hostedtoolcache/Python/3.11.9/x64/bin
   [test_python/test_python-3] ⭐ Run Main SETUP - Display Python version
   | ============================= test session starts ==============================
   | platform linux -- Python 3.10.14, pytest-7.1.3, pluggy-1.5.0 -- /Users/joe.barnett/company/code/cloudzero-charts-jb/charts/cloudzero-agent/venv/bin/python
   | cachedir: .pytest_cache
   | rootdir: /Users/joe.barnett/company/code/cloudzero-charts-jb/charts/cloudzero-agent
   | plugins: cov-4.0.0, mock-3.14.0
   [test_python/test_python-3]   🐳  docker exec cmd=[bash --noprofile --norc -e -o pipefail /var/run/act/workflow/2] user= workdir=
   | ============================= test session starts ==============================
   | platform linux -- Python 3.9.19, pytest-7.1.3, pluggy-1.5.0 -- /Users/joe.barnett/company/code/cloudzero-charts-jb/charts/cloudzero-agent/venv/bin/python
   | cachedir: .pytest_cache
   | rootdir: /Users/joe.barnett/company/code/cloudzero-charts-jb/charts/cloudzero-agent
   | plugins: cov-4.0.0, mock-3.14.0
   collected 6 items                                                              
   | 
   | 3.11.9 (main, Jun 20 2024, 16:02:53) [GCC 11.4.0]
   | tests/test_validations.py::test_check_service_availability_success PASSED [ 16%]
   [test_python/test_python-3]   ✅  Success - Main SETUP - Display Python version
   [test_python/test_python-3] ⭐ Run Main TEST - Run checks
   [test_python/test_python-3]   🐳  docker exec cmd=[bash --noprofile --norc -e -o pipefail /var/run/act/workflow/3] user= workdir=
   collected 6 items                                                              
   | 
   | tests/test_validations.py::test_check_service_availability_success PASSED [ 16%]
   | tests/test_validations.py::test_check_service_availability_failure PASSED [ 33%]
   | tests/test_validations.py::test_check_external_connectivity PASSED       [ 50%]
   | tests/test_validations.py::test_check_kube_state_metrics PASSED          [ 66%]
   | tests/test_validations.py::test_check_prometheus_node_exporter PASSED    [ 83%]
   | tests/test_validations.py::test_run_validations PASSED                   [100%]
   | 
   | ============================== 6 passed in 0.24s ===============================
   [test_python/test_python-2]   ✅  Success - Main TEST - Run checks
   [test_python/test_python-2] ⭐ Run Post SETUP - Python 3.10
   | tests/test_validations.py::test_check_service_availability_failure PASSED [ 33%]
   [test_python/test_python-2]   🐳  docker exec cmd=[node /var/run/act/actions/actions-setup-python@v5/dist/cache-save/index.js] user= workdir=
   | tests/test_validations.py::test_check_external_connectivity PASSED       [ 50%]
   | tests/test_validations.py::test_check_kube_state_metrics PASSED          [ 66%]
   | tests/test_validations.py::test_check_prometheus_node_exporter PASSED    [ 83%]
   | tests/test_validations.py::test_run_validations PASSED                   [100%]
   | 
   | ============================== 6 passed in 0.27s ===============================
   [test_python/test_python-1]   ✅  Success - Main TEST - Run checks
   [test_python/test_python-1] ⭐ Run Post SETUP - Python 3.9
   [test_python/test_python-1]   🐳  docker exec cmd=[node /var/run/act/actions/actions-setup-python@v5/dist/cache-save/index.js] user= workdir=
   | ============================= test session starts ==============================
   | platform linux -- Python 3.12.4, pytest-7.1.3, pluggy-1.5.0 -- /Users/joe.barnett/company/code/cloudzero-charts-jb/charts/cloudzero-agent/venv/bin/python
   | cachedir: .pytest_cache
   | rootdir: /Users/joe.barnett/company/code/cloudzero-charts-jb/charts/cloudzero-agent
   | plugins: cov-4.0.0, mock-3.14.0
   collected 6 items                                                              
   | 
   | tests/test_validations.py::test_check_service_availability_success PASSED [ 16%]
   | tests/test_validations.py::test_check_service_availability_failure PASSED [ 33%]
   | tests/test_validations.py::test_check_external_connectivity PASSED       [ 50%]
   | tests/test_validations.py::test_check_kube_state_metrics PASSED          [ 66%]
   | tests/test_validations.py::test_check_prometheus_node_exporter PASSED    [ 83%]
   | tests/test_validations.py::test_run_validations PASSED                   [100%]
   | 
   | =============================== warnings summary ===============================
   | venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:940
   | venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:940
   | venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:940
   | venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:940
   | venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:940
   | venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:940
   | venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:940
   |   /Users/joe.barnett/company/code/cloudzero-charts-jb/charts/cloudzero-agent/venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:940: DeprecationWarning: ast.Str is deprecated and will be removed in Python 3.14; use ast.Constant instead
   |     inlocs = ast.Compare(ast.Str(name.id), [ast.In()], [locs])
   | 
   | venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:943
   | venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:943
   | venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:943
   | venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:943
   | venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:943
   | venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:943
   | venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:943
   |   /Users/joe.barnett/company/code/cloudzero-charts-jb/charts/cloudzero-agent/venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:943: DeprecationWarning: ast.Str is deprecated and will be removed in Python 3.14; use ast.Constant instead
   |     expr = ast.IfExp(test, self.display(name), ast.Str(name.id))
   | 
   | venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:1053
   | venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:1053
   | venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:1053
   | venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:1053
   | venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:1053
   | venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:1053
   |   /Users/joe.barnett/company/code/cloudzero-charts-jb/charts/cloudzero-agent/venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:1053: DeprecationWarning: ast.Str is deprecated and will be removed in Python 3.14; use ast.Constant instead
   |     syms.append(ast.Str(sym))
   | 
   | venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:1055
   | venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:1055
   | venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:1055
   | venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:1055
   | venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:1055
   | venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:1055
   |   /Users/joe.barnett/company/code/cloudzero-charts-jb/charts/cloudzero-agent/venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:1055: DeprecationWarning: ast.Str is deprecated and will be removed in Python 3.14; use ast.Constant instead
   |     expls.append(ast.Str(expl))
   | 
   | venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:804: 20 warnings
   |   /Users/joe.barnett/company/code/cloudzero-charts-jb/charts/cloudzero-agent/venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:804: DeprecationWarning: ast.Str is deprecated and will be removed in Python 3.14; use ast.Constant instead
   |     keys = [ast.Str(key) for key in current.keys()]
   | 
   | venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:914
   | venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:914
   | venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:914
   | venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:914
   | venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:914
   | venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:914
   | venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:914
   | venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:914
   |   /Users/joe.barnett/company/code/cloudzero-charts-jb/charts/cloudzero-agent/venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:914: DeprecationWarning: ast.Str is deprecated and will be removed in Python 3.14; use ast.Constant instead
   |     assertmsg = ast.Str("")
   | 
   | venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:916
   | venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:916
   | venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:916
   | venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:916
   | venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:916
   | venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:916
   | venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:916
   | venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:916
   |   /Users/joe.barnett/company/code/cloudzero-charts-jb/charts/cloudzero-agent/venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:916: DeprecationWarning: ast.Str is deprecated and will be removed in Python 3.14; use ast.Constant instead
   |     template = ast.BinOp(assertmsg, ast.Add(), ast.Str(explanation))
   | 
   | venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:928
   | venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:928
   | venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:928
   | venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:928
   | venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:928
   | venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:928
   | venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:928
   | venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:928
   |   /Users/joe.barnett/company/code/cloudzero-charts-jb/charts/cloudzero-agent/venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:928: DeprecationWarning: ast.NameConstant is deprecated and will be removed in Python 3.14; use ast.Constant instead
   |     clear = ast.Assign(variables, ast.NameConstant(None))
   | 
   | -- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
   | ======================== 6 passed, 70 warnings in 0.24s ========================
   [test_python/test_python-4]   ✅  Success - Main TEST - Run checks
   [test_python/test_python-2]   ✅  Success - Post SETUP - Python 3.10
   [test_python/test_python-2] Cleaning up container for job test_python
   [test_python/test_python-4] ⭐ Run Post SETUP - Python 3.12
   [test_python/test_python-4]   🐳  docker exec cmd=[node /var/run/act/actions/actions-setup-python@v5/dist/cache-save/index.js] user= workdir=
   [test_python/test_python-2] 🏁  Job succeeded
   [test_python/test_python-1]   ✅  Success - Post SETUP - Python 3.9
   [test_python/test_python-1] Cleaning up container for job test_python
   [test_python/test_python-1] 🏁  Job succeeded
   [test_python/test_python-4]   ✅  Success - Post SETUP - Python 3.12
   [test_python/test_python-4] Cleaning up container for job test_python
   [test_python/test_python-4] 🏁  Job succeeded
   | Collecting requests==2.32.3 (from -r src/requirements.txt (line 1))
   |   Downloading requests-2.32.3-py3-none-any.whl.metadata (4.6 kB)
   | Collecting charset-normalizer<4,>=2 (from requests==2.32.3->-r src/requirements.txt (line 1))
   |   Downloading charset_normalizer-3.3.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (33 kB)
   | Collecting idna<4,>=2.5 (from requests==2.32.3->-r src/requirements.txt (line 1))
   |   Downloading idna-3.7-py3-none-any.whl.metadata (9.9 kB)
   | Collecting urllib3<3,>=1.21.1 (from requests==2.32.3->-r src/requirements.txt (line 1))
   |   Downloading urllib3-2.2.2-py3-none-any.whl.metadata (6.4 kB)
   | Collecting certifi>=2017.4.17 (from requests==2.32.3->-r src/requirements.txt (line 1))
   |   Downloading certifi-2024.6.2-py3-none-any.whl.metadata (2.2 kB)
   | Downloading requests-2.32.3-py3-none-any.whl (64 kB)
      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 64.9/64.9 kB 7.0 MB/s eta 0:00:00
   | Downloading certifi-2024.6.2-py3-none-any.whl (164 kB)
      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 164.4/164.4 kB 9.0 MB/s eta 0:00:00
   | Downloading charset_normalizer-3.3.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (140 kB)
      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 140.3/140.3 kB 10.2 MB/s eta 0:00:00
   | Downloading idna-3.7-py3-none-any.whl (66 kB)
      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 66.8/66.8 kB 3.8 MB/s eta 0:00:00
   | Downloading urllib3-2.2.2-py3-none-any.whl (121 kB)
      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 121.4/121.4 kB 8.2 MB/s eta 0:00:00
   | Installing collected packages: urllib3, idna, charset-normalizer, certifi, requests
   | Successfully installed certifi-2024.6.2 charset-normalizer-3.3.2 idna-3.7 requests-2.32.3 urllib3-2.2.2
   | 
   | [notice] A new release of pip is available: 24.0 -> 24.1
   | [notice] To update, run: pip install --upgrade pip
   | Collecting black==22.3.0 (from -r tests/requirements.txt (line 6))
   |   Downloading black-22.3.0-py3-none-any.whl.metadata (45 kB)
      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 45.6/45.6 kB 4.2 MB/s eta 0:00:00
   | Collecting click==8.1.3 (from -r tests/requirements.txt (line 7))
   |   Downloading click-8.1.3-py3-none-any.whl.metadata (3.2 kB)
   | Collecting pytest==7.1.3 (from -r tests/requirements.txt (line 8))
   |   Downloading pytest-7.1.3-py3-none-any.whl.metadata (7.7 kB)
   | Collecting pytest-cov==4.0.0 (from -r tests/requirements.txt (line 9))
   |   Downloading pytest_cov-4.0.0-py3-none-any.whl.metadata (25 kB)
   | Collecting pytest-mock (from -r tests/requirements.txt (line 10))
   |   Downloading pytest_mock-3.14.0-py3-none-any.whl.metadata (3.8 kB)
   | Collecting ruff==0.0.284 (from -r tests/requirements.txt (line 12))
   |   Downloading ruff-0.0.284-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (21 kB)
   | Collecting platformdirs>=2 (from black==22.3.0->-r tests/requirements.txt (line 6))
   |   Downloading platformdirs-4.2.2-py3-none-any.whl.metadata (11 kB)
   | Collecting pathspec>=0.9.0 (from black==22.3.0->-r tests/requirements.txt (line 6))
   |   Downloading pathspec-0.12.1-py3-none-any.whl.metadata (21 kB)
   | Collecting mypy-extensions>=0.4.3 (from black==22.3.0->-r tests/requirements.txt (line 6))
   |   Downloading mypy_extensions-1.0.0-py3-none-any.whl.metadata (1.1 kB)
   | Collecting attrs>=19.2.0 (from pytest==7.1.3->-r tests/requirements.txt (line 8))
   |   Downloading attrs-23.2.0-py3-none-any.whl.metadata (9.5 kB)
   | Collecting iniconfig (from pytest==7.1.3->-r tests/requirements.txt (line 8))
   |   Downloading iniconfig-2.0.0-py3-none-any.whl.metadata (2.6 kB)
   | Collecting packaging (from pytest==7.1.3->-r tests/requirements.txt (line 8))
   |   Downloading packaging-24.1-py3-none-any.whl.metadata (3.2 kB)
   | Collecting pluggy<2.0,>=0.12 (from pytest==7.1.3->-r tests/requirements.txt (line 8))
   |   Downloading pluggy-1.5.0-py3-none-any.whl.metadata (4.8 kB)
   | Collecting py>=1.8.2 (from pytest==7.1.3->-r tests/requirements.txt (line 8))
   |   Downloading py-1.11.0-py2.py3-none-any.whl.metadata (2.8 kB)
   | Collecting tomli>=1.0.0 (from pytest==7.1.3->-r tests/requirements.txt (line 8))
   |   Downloading tomli-2.0.1-py3-none-any.whl.metadata (8.9 kB)
   | Collecting coverage>=5.2.1 (from coverage[toml]>=5.2.1->pytest-cov==4.0.0->-r tests/requirements.txt (line 9))
   |   Downloading coverage-7.5.4-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (8.2 kB)
   | Downloading black-22.3.0-py3-none-any.whl (153 kB)
      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 153.9/153.9 kB 6.6 MB/s eta 0:00:00
   | Downloading click-8.1.3-py3-none-any.whl (96 kB)
      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 96.6/96.6 kB 5.7 MB/s eta 0:00:00
   | Downloading pytest-7.1.3-py3-none-any.whl (298 kB)
      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 298.2/298.2 kB 10.1 MB/s eta 0:00:00
   | Downloading pytest_cov-4.0.0-py3-none-any.whl (21 kB)
   | Downloading ruff-0.0.284-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (5.7 MB)
      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 5.7/5.7 MB 26.6 MB/s eta 0:00:00
   | Downloading pytest_mock-3.14.0-py3-none-any.whl (9.9 kB)
   | Downloading attrs-23.2.0-py3-none-any.whl (60 kB)
      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 60.8/60.8 kB 4.3 MB/s eta 0:00:00
   | Downloading coverage-7.5.4-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl (236 kB)
      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 237.0/237.0 kB 13.8 MB/s eta 0:00:00
   | Downloading mypy_extensions-1.0.0-py3-none-any.whl (4.7 kB)
   | Downloading pathspec-0.12.1-py3-none-any.whl (31 kB)
   | Downloading platformdirs-4.2.2-py3-none-any.whl (18 kB)
   | Downloading pluggy-1.5.0-py3-none-any.whl (20 kB)
   | Downloading py-1.11.0-py2.py3-none-any.whl (98 kB)
      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 98.7/98.7 kB 7.3 MB/s eta 0:00:00
   | Downloading tomli-2.0.1-py3-none-any.whl (12 kB)
   | Downloading iniconfig-2.0.0-py3-none-any.whl (5.9 kB)
   | Downloading packaging-24.1-py3-none-any.whl (53 kB)
      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 54.0/54.0 kB 6.4 MB/s eta 0:00:00
   | Installing collected packages: tomli, ruff, py, pluggy, platformdirs, pathspec, packaging, mypy-extensions, iniconfig, coverage, click, attrs, pytest, black, pytest-mock, pytest-cov
   | Successfully installed attrs-23.2.0 black-22.3.0 click-8.1.3 coverage-7.5.4 iniconfig-2.0.0 mypy-extensions-1.0.0 packaging-24.1 pathspec-0.12.1 platformdirs-4.2.2 pluggy-1.5.0 py-1.11.0 pytest-7.1.3 pytest-cov-4.0.0 pytest-mock-3.14.0 ruff-0.0.284 tomli-2.0.1
   | 
   | [notice] A new release of pip is available: 24.0 -> 24.1
   | [notice] To update, run: pip install --upgrade pip
   | All done! ✨ 🍰 ✨
   | 2 files left unchanged.
   | ============================= test session starts ==============================
   | platform linux -- Python 3.11.9, pytest-7.1.3, pluggy-1.5.0 -- /Users/joe.barnett/company/code/cloudzero-charts-jb/charts/cloudzero-agent/venv/bin/python
   | cachedir: .pytest_cache
   | rootdir: /Users/joe.barnett/company/code/cloudzero-charts-jb/charts/cloudzero-agent
   | plugins: cov-4.0.0, mock-3.14.0
   collected 6 items                                                              
   | 
   | tests/test_validations.py::test_check_service_availability_success PASSED [ 16%]
   | tests/test_validations.py::test_check_service_availability_failure PASSED [ 33%]
   | tests/test_validations.py::test_check_external_connectivity PASSED       [ 50%]
   | tests/test_validations.py::test_check_kube_state_metrics PASSED          [ 66%]
   | tests/test_validations.py::test_check_prometheus_node_exporter PASSED    [ 83%]
   | tests/test_validations.py::test_run_validations PASSED                   [100%]
   | 
   | ============================== 6 passed in 0.20s ===============================
   [test_python/test_python-3]   ✅  Success - Main TEST - Run checks
   [test_python/test_python-3] ⭐ Run Post SETUP - Python 3.11
   [test_python/test_python-3]   🐳  docker exec cmd=[node /var/run/act/actions/actions-setup-python@v5/dist/cache-save/index.js] user= workdir=
   [test_python/test_python-3]   ✅  Success - Post SETUP - Python 3.11
   [test_python/test_python-3] Cleaning up container for job test_python
   [test_python/test_python-3] 🏁  Job succeeded
   ➜  cloudzero-charts-jb git:(CP-19161-ensure-we-have-good-testing-on-new-validator-code) 
   ```
</details>