### PR TITLE
CP-19767: only scrape config should be overwritten by configOverride, allows users to set individual jobs

### DIFF
--- a/charts/cloudzero-agent/CHANGELOG.md
+++ b/charts/cloudzero-agent/CHANGELOG.md
@@ -5,10 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.0.8]
+## [0.0.9]
+
+### Added
+- `prometheusConfig.scrapeJobs` is added to allow more granular control of scrape jobs.
 
 ### Fixed
 - `prometheusConfig.configOverride` only replaces the scrape_configs in the Prometheus configuration.
+
+## [0.0.8]
+
+### Added
+- Environment validation is now done upon agent initialization
 
 ## [0.0.7]
 

--- a/charts/cloudzero-agent/CHANGELOG.md
+++ b/charts/cloudzero-agent/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.8]
+
+### Fixed
+- `prometheusConfig.configOverride` only replaces the scrape_configs in the Prometheus configuration.
+
 ## [0.0.7]
 
 ### Added

--- a/charts/cloudzero-agent/README.md
+++ b/charts/cloudzero-agent/README.md
@@ -67,7 +67,7 @@ This will deploy the required resources for metric scraping.
 ### Custom Scrape Configs
 If the chart is running *without* the `kube-state-metrics` and `prometheus-node-exporter` exporters enabled (meaning, those two exporters are deployed from some other source outside of this chart), then the scrape configs used by the underlying Prometheus agent may need to be adjusted.
 
-As an example, the out-of-the-box scrape config in this chart attempts to find the `kube-state-metrics` exporter via an annotation on a k8s `endpoints` resource deployed by the KSM subchart. If `kube-state-metrics` was instead deployed without any annotations, and was only available via a Service, we could add the following:
+As an example, the out-of-the-box scrape config in this chart attempts to find the `kube-state-metrics` exporter via an annotation on a k8s `endpoints` resource deployed by the KSM subchart. If `kube-state-metrics` was instead deployed without any annotations, and was only available via a Service with the address `my-kube-state-metrics-service.default.svc.cluster.local` on port 8080, we could add the following:
 
 custom-scrape-config.yaml
 ```yaml

--- a/charts/cloudzero-agent/README.md
+++ b/charts/cloudzero-agent/README.md
@@ -65,7 +65,7 @@ prometheus-node-exporter:
 This will deploy the required resources for metric scraping.
 
 ### Custom Scrape Configs
-If the chart is running *without* the `kube-state-metrics` and `prometheus-node-exporter` exporters enabled (meaning, those two exporters must be deployed from some other source), then the scrape configs used by the underlying Prometheus agent may need to be adjusted.
+If the chart is running *without* the `kube-state-metrics` and `prometheus-node-exporter` exporters enabled (meaning, those two exporters are deployed from some other source outside of this chart), then the scrape configs used by the underlying Prometheus agent may need to be adjusted.
 
 As an example, the out-of-the-box scrape config in this chart attempts to find the `kube-state-metrics` exporter via an annotation on a k8s `endpoints` resource deployed by the KSM subchart. If `kube-state-metrics` was instead deployed without any annotations, and was only available via a Service, we could add the following:
 
@@ -84,7 +84,7 @@ prometheusConfig:
       metrics_path: /metrics
       static_configs:
         - targets:
-          - 'cloudzero-agent-with-ui-kube-state-metrics.default.svc.cluster.local:8080'
+          - 'my-kube-state-metrics-service.default.svc.cluster.local:8080'
       relabel_configs:
       - separator: ;
         regex: __meta_kubernetes_service_label_(.+)

--- a/charts/cloudzero-agent/templates/cm.yaml
+++ b/charts/cloudzero-agent/templates/cm.yaml
@@ -142,6 +142,7 @@ data:
           kubeconfig_file: ""
           follow_redirects: true
           enable_http2: true
+    {{- end}}
     remote_write:
       - url: 'https://{{ .Values.host }}/v1/container-metrics?cluster_name={{.Values.clusterName}}&cloud_account_id={{.Values.cloudAccountId | toString}}'
         authorization:
@@ -152,4 +153,3 @@ data:
             action: keep
         metadata_config:
           send: false
-    {{- end}}

--- a/charts/cloudzero-agent/templates/cm.yaml
+++ b/charts/cloudzero-agent/templates/cm.yaml
@@ -146,7 +146,7 @@ data:
           follow_redirects: true
           enable_http2: true
     {{- end }}
-    {{- if .Values.prometheusConfig.scrapeJobs.additionalScrapeJobs }}
+    {{- if .Values.prometheusConfig.scrapeJobs.additionalScrapeJobs -}}
     {{ toYaml .Values.prometheusConfig.scrapeJobs.additionalScrapeJobs | toString | nindent 6 }}
     {{- end}}
     {{- end}}

--- a/charts/cloudzero-agent/templates/cm.yaml
+++ b/charts/cloudzero-agent/templates/cm.yaml
@@ -146,7 +146,9 @@ data:
           follow_redirects: true
           enable_http2: true
     {{- end }}
+    {{- if .Values.prometheusConfig.scrapeJobs.additionalScrapeJobs }}
     {{ toYaml .Values.prometheusConfig.scrapeJobs.additionalScrapeJobs | toString | nindent 6 }}
+    {{- end}}
     {{- end}}
     remote_write:
       - url: 'https://{{ .Values.host }}/v1/container-metrics?cluster_name={{.Values.clusterName}}&cloud_account_id={{.Values.cloudAccountId | toString}}'

--- a/charts/cloudzero-agent/templates/cm.yaml
+++ b/charts/cloudzero-agent/templates/cm.yaml
@@ -17,6 +17,7 @@ data:
     global:
       scrape_interval: 60s
     scrape_configs:
+      {{- if .Values.prometheusConfig.scrapeJobs.kubeStateMetrics.enabled }}
       - job_name: cloudzero-service-endpoints # kube_*, node_* metrics
         honor_labels: true
         honor_timestamps: true
@@ -92,6 +93,8 @@ data:
           kubeconfig_file: ""
           follow_redirects: true
           enable_http2: true
+      {{- end }}
+      {{- if .Values.prometheusConfig.scrapeJobs.cadvisor.enabled }}
       - job_name: cloudzero-nodes-cadvisor # container_* metrics
         honor_timestamps: true
         track_timestamps_staleness: false
@@ -142,6 +145,8 @@ data:
           kubeconfig_file: ""
           follow_redirects: true
           enable_http2: true
+    {{- end }}
+    {{ toYaml .Values.prometheusConfig.scrapeJobs.additionalScrapeJobs | toString | nindent 6 }}
     {{- end}}
     remote_write:
       - url: 'https://{{ .Values.host }}/v1/container-metrics?cluster_name={{.Values.clusterName}}&cloud_account_id={{.Values.cloudAccountId | toString}}'

--- a/charts/cloudzero-agent/values.yaml
+++ b/charts/cloudzero-agent/values.yaml
@@ -31,13 +31,13 @@ prometheusConfig:
   configMapAnnotations: {}
   configOverride: ''
   scrapeJobs:
-    -- Enables the kube-state-metrics scrape job.
+    # -- Enables the kube-state-metrics scrape job.
     kubeStateMetrics:
       enabled: true
-    -- Enables the cadvisor scrape job.
+    # -- Enables the cadvisor scrape job.
     cadvisor:
       enabled: true
-    -- Any items added to this list will be added to the Prometheus scrape configuration.
+    # -- Any items added to this list will be added to the Prometheus scrape configuration.
     additionalScrapeJobs: []
 
 

--- a/charts/cloudzero-agent/values.yaml
+++ b/charts/cloudzero-agent/values.yaml
@@ -30,6 +30,16 @@ prometheusConfig:
   configMapNameOverride: ''
   configMapAnnotations: {}
   configOverride: ''
+  scrapeJobs:
+    -- Enables the kube-state-metrics scrape job.
+    kubeStateMetrics:
+      enabled: true
+    -- Enables the cadvisor scrape job.
+    cadvisor:
+      enabled: true
+    -- Any items added to this list will be added to the Prometheus scrape configuration.
+    additionalScrapeJobs: []
+
 
 kube-state-metrics:
   enabled: false


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [CloudZero Code of Conduct](https://github.com/cloudzero/template-cloudzero-open-source/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/cloudzero/template-cloudzero-open-source/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description
If a user wants to provide a custom scrape config, the current `configOverride` param forces them to also supply the remote_write config. This is doable, but requires the user to maintain a static version of the remote_write config. The `configOverride` should only overwrite the scrape_configs section

additionally, users can use the `scrapeJobs` array to add arbitrary scrape jobs


### Testing

1. using helm template, asserted that running without an override produces the same output as develop branch
2. given the following `custom-scrape-config.yaml` file:
```yaml
prometheusConfig:
  scrapeJobs:
    kubeStateMetrics:
      enabled: false
    additionalScrapeJobs:
    - job_name: custom-scrape-job
      foo: bar

```
the following valid configmap is produced:
```yaml
helm template cloudzero-agent ./ --set apiKey=foobar --set clusterName=foobar --set cloudAccountId=12345678910 -f test-config.yaml  | grep cm.yaml -A 100
# Source: cloudzero-agent/templates/cm.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  labels:
    app.kubernetes.io/component: server
    app.kubernetes.io/name: cloudzero-agent
    app.kubernetes.io/instance: cloudzero-agent
    app.kubernetes.io/version: v2.50.1
    helm.sh/chart: cloudzero-agent-0.0.8
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/part-of: cloudzero-agent
  name: cloudzero-agent-configuration
  namespace: default
data:
  prometheus.yml: |-
    global:
      scrape_interval: 60s
    scrape_configs:
      - job_name: cloudzero-nodes-cadvisor # container_* metrics
        honor_timestamps: true
        track_timestamps_staleness: false
        scrape_interval: 1m
        scrape_timeout: 10s
        scrape_protocols:
        - OpenMetricsText1.0.0
        - OpenMetricsText0.0.1
        - PrometheusText0.0.4
        metrics_path: /metrics
        scheme: https
        enable_compression: true
        authorization:
          type: Bearer
          credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
        tls_config:
          ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
          insecure_skip_verify: true
        follow_redirects: true
        enable_http2: true
        relabel_configs:
        - separator: ;
          regex: __meta_kubernetes_node_label_(.+)
          replacement: $1
          action: labelmap
        - separator: ;
          regex: (.*)
          target_label: __address__
          replacement: kubernetes.default.svc:443
          action: replace
        - source_labels: [__meta_kubernetes_node_name]
          separator: ;
          regex: (.+)
          target_label: __metrics_path__
          replacement: /api/v1/nodes/$1/proxy/metrics/cadvisor
          action: replace
        - source_labels: [__meta_kubernetes_node_name]
          target_label: node
          action: replace
        metric_relabel_configs:
        - action: labeldrop
          regex: instance
        - source_labels: [__name__]
          regex: "^(container_cpu_usage_seconds_total|container_memory_working_set_bytes|container_network_receive_bytes_total|container_network_transmit_bytes_total)$"
          action: keep
        kubernetes_sd_configs:
        - role: node
          kubeconfig_file: ""
          follow_redirects: true
          enable_http2: true
      - foo: bar
        job_name: custom-scrape-job
```
3. given the following `custom-scrape-config.yaml` file:
```yaml
prometheusConfig:
  scrapeJobs:
    kubeStateMetrics:
      enabled: false
    additionalScrapeJobs:
    - job_name: custom-kube-state-metrics
      honor_labels: true
      honor_timestamps: true
      scrape_interval: 1m
      scrape_timeout: 10s
      metrics_path: /metrics
      static_configs:
        - targets:
          - 'cloudzero-agent-with-ui-kube-state-metrics.default.svc.cluster.local:8080'
      relabel_configs:
      - separator: ;
        regex: __meta_kubernetes_service_label_(.+)
        replacement: $1
        action: labelmap
      - source_labels: [__meta_kubernetes_namespace]
        separator: ;
        regex: (.*)
        target_label: namespace
        replacement: $1
        action: replace
      - source_labels: [__meta_kubernetes_service_name]
        separator: ;
        regex: (.*)
        target_label: service
        replacement: $1
        action: replace
      kubernetes_sd_configs:
      - role: service
        kubeconfig_file: ""
        follow_redirects: true
        enable_http2: true
```
a helm release deployed with this command: 

```bash
helm upgrade --install cloudzero-agent-with-ui ./ --set apiKey=foobar --set clusterName=foobar --set cloudAccountId=12345678910 --set kube-state-metrics.enabled=true --set prometheus-node-exporter.enabled=true  --set "server.args={--config.file=/etc/config/prometheus/configmaps/prometheus.yml,--web.enable-lifecycle,--web.console.libraries=/etc/prometheus/console_libraries,--web.console.templates=/etc/prometheus/consoles}" -f custom-scrape-config.yaml
```

![Screenshot 2024-06-27 at 1 07 33 PM](https://github.com/Cloudzero/cloudzero-charts/assets/10842369/5633df4f-612c-4eb6-afad-297d01afdfa8)

The prometheus UI shows the expected KSM metrics


- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`