### PR TITLE
CP-19612: Update cloudzero-agent chart to include region parameter

### DIFF
--- a/.github/workflows/build-test-publish-image.yml
+++ b/.github/workflows/build-test-publish-image.yml
@@ -54,14 +54,15 @@ jobs:
           PROM_CHART_REPO: https://prometheus-community.github.io/helm-charts
           CLUSTER_NAME: cz-node-agent-ci
           CLOUD_ACCOUNT_ID: 00000000
-          CZ_API_TOKEN: 'undefined'
+          CZ_API_TOKEN: 'fake-api-token'
+          REGION: 'us-east-1'
         run: |
           cd charts/cloudzero-agent
           helm dependency update
           ct lint --debug --charts . \
             --chart-repos=kube-state-metrics=$PROM_CHART_REPO \
             --chart-repos=prometheus-node-exporter=$PROM_CHART_REPO \
-            --helm-lint-extra-args "--set=existingSecretName=api-token,clusterName=$CLUSTER_NAME,cloudAccountId=$CLOUD_ACCOUNT_ID"
+            --helm-lint-extra-args "--set=existingSecretName=api-token,clusterName=$CLUSTER_NAME,cloudAccountId=$CLOUD_ACCOUNT_ID,region=$REGION"
 
   # This job tests the chart on a KinD cluster
   # and if we are in the develop or tag branch, it will 
@@ -185,7 +186,8 @@ jobs:
           PROM_CHART_REPO: https://prometheus-community.github.io/helm-charts
           CLUSTER_NAME: cz-node-agent-ci
           CLOUD_ACCOUNT_ID: 00000000
-          CZ_API_TOKEN: ${{ secrets.CZ_API_TOKEN || 'undefined' }}
+          CZ_API_TOKEN: ${{ secrets.CZ_API_TOKEN || 'fake-api-token' }}
+          REGION: 'us-east-1'
         run: |
           # use the test address for the image (k8s accesses via network alias)
           image_name="${{ env.REGISTRY_TEST_ADDR }}/${{ env.IMAGE_NAME }}"
@@ -210,6 +212,7 @@ jobs:
               --set=existingSecretName=api-token \
               --set=clusterName=$CLUSTER_NAME \
               --set=cloudAccountId=$CLOUD_ACCOUNT_ID \
+              --set=region=$REGION \
               --set=kube-state-metrics.enabled=true \
               --set=prometheus-node-exporter.enabled=true"
       

--- a/charts/cloudzero-agent/README.md
+++ b/charts/cloudzero-agent/README.md
@@ -32,12 +32,13 @@ If installing with Helm directly, the following command will install the chart:
 helm install <RELEASE_NAME> cloudzero/cloudzero-agent \
     --set existingSecretName=<NAME_OF_SECRET> \
     --set clusterName=<CLUSTER_NAME> \
-    --set cloudAccountId=<CLOUD_ACCOUNT_ID>
+    --set cloudAccountId=<CLOUD_ACCOUNT_ID> \
+    --set region=<REGION>
 ```
 
 ### Secret Management
 
-The chart requires an CloudZero API key in order to send metric data to the CloudZero platform. Admins can retrieve API keys [here](https://app.cloudzero.com/organization/api-keys).
+The chart requires a CloudZero API key in order to send metric data to the CloudZero platform. Admins can retrieve API keys [here](https://app.cloudzero.com/organization/api-keys).
 
 The Deployment running Prometheus ingests the API key via a Secret; this Secret can be supplied as an existing secret (default), or created by the chart. Both methods will require the API key retrieved from the CloudZero platform.
 
@@ -85,11 +86,12 @@ See the `kube-state-metrics` [documentation](https://github.com/kubernetes/kube-
 
 | Key               | Type   | Default               | Description                                                                                                             |
 |-------------------|--------|-----------------------|-------------------------------------------------------------------------------------------------------------------------|
-| cloudAccountId    | string | `nil`                 | Account ID in AWS or Subscription ID in Azure of the account the cluster is running in.                                                                    |
+| cloudAccountId    | string | `nil`                 | Account ID in AWS or Subscription ID in Azure of the account the cluster is running in.                                 |
 | clusterName       | string | `nil`                 | Name of the cluster. Required to be RFC 1123 compliant.                                                                 |
 | host              | string | `"api.cloudzero.com"` | CloudZero host to send metrics to.                                                                                      |
 | apiKey            | string | `nil`                 | The CloudZero API key to use to export metrics. Only used if `existingSecretName` is not set.                           |
-| existingSecretName| string | `nil`                  | The name of the secret that contains the CloudZero API key. Required if not providing the API key via the apiKey value.|
+| existingSecretName| string | `nil`                 | The name of the secret that contains the CloudZero API key. Required if not providing the API key via the apiKey value. |
+| region            | string | `nil`                 | Region the cluster is running in.                                                                                       |
 
 
 ## Requirements

--- a/charts/cloudzero-agent/docs/cicd-chart-testing.md
+++ b/charts/cloudzero-agent/docs/cicd-chart-testing.md
@@ -31,7 +31,7 @@ Stage  Job ID                                        Job name                   
 To verify a specific workflow in DRY-RUN mode, use the following command:
 
 ```bash
-act --dry-run -j build_test_chart_install_maybe_publish_image -s CLOUDZERO_API_TOKEN=$CZ_API_TOKEN -a $GITHUB_USER --secret GITHUB_TOKEN=$GITHUB_TOKEN
+act --dry-run -j build_test_chart_install_maybe_publish_image -s CZ_API_TOKEN=$CZ_API_TOKEN -a $GITHUB_USER --secret GITHUB_TOKEN=$GITHUB_TOKEN
 ```
 
 Please note that adding the `-n` or `--dry-run` flag only validates that the jobs are syntactically correct.
@@ -41,7 +41,7 @@ Please note that adding the `-n` or `--dry-run` flag only validates that the job
 To run a specific workflow, use the following command:
 
 ```bash
-act --dry-run -j build_test_chart_install_maybe_publish_image -s CLOUDZERO_API_TOKEN=$CZ_API_TOKEN -a $GITHUB_USER --secret GITHUB_TOKEN=$GITHUB_TOKEN
+act --dry-run -j build_test_chart_install_maybe_publish_image -s CZ_API_TOKEN=$CZ_API_TOKEN -a $GITHUB_USER --secret GITHUB_TOKEN=$GITHUB_TOKEN
 ```
 
 ---

--- a/charts/cloudzero-agent/src/validate.py
+++ b/charts/cloudzero-agent/src/validate.py
@@ -4,17 +4,19 @@ import os
 import requests
 import sys
 import time
-from typing import Dict, Tuple, Callable, List
+from typing import Dict, Tuple, Callable, List, Optional
 
 MAX_RETRY = 12
 RETRY_INTERVAL = 10
 
 
-def check_service_availability(url: str, key: str) -> Tuple[str, str]:
+def check_service_availability(
+    url: str, key: str, headers: Optional[dict] = None
+) -> Tuple[str, str]:
     # only wait two minutes max
     for _ in range(MAX_RETRY):
         try:
-            response = requests.get(url)
+            response = requests.get(url, headers=headers)
             response.raise_for_status()
             return (key, "success")
         except Exception:
@@ -23,6 +25,42 @@ def check_service_availability(url: str, key: str) -> Tuple[str, str]:
 
     print(f"{key} not ready after {MAX_RETRY} retries", file=sys.stderr)
     return (key, "failure")
+
+
+def get_api_key():
+    secret_file_path = "/etc/config/prometheus/secrets/value"
+
+    try:
+        with open(secret_file_path, "r") as file:
+            secret_value = file.read().strip()
+        return secret_value
+    except FileNotFoundError:
+        print(f"Secret file {secret_file_path} not found.", file=sys.stderr)
+        return None
+
+
+def check_external_validation_endpoint() -> Tuple[str, str]:
+    host: str = os.getenv("CZ_HOST", "api.cloudzero.com")
+    api_key = get_api_key()
+
+    if not host:
+        print("Failed to find a host", file=sys.stderr)
+        return ("check_external_validation_endpoint", "failure")
+
+    if not api_key:
+        print("Failed to find an api key", file=sys.stderr)
+        return ("check_external_validation_endpoint", "failure")
+
+    # Future: Hit an endpoint that validates more of the data
+    # For now this just validates that the API key is valid
+    url: str = f"https://{host}/v2/insights"
+
+    print(f"Checking external connectivity to {url}", file=sys.stderr)
+
+    headers = {"Authorization": f"Bearer {api_key}"}
+    return check_service_availability(
+        url, "check_external_validation_endpoint", headers
+    )
 
 
 def check_external_connectivity() -> Tuple[str, str]:
@@ -47,6 +85,7 @@ validations: List[Callable[[], Tuple[str, str]]] = [
     check_external_connectivity,
     check_kube_state_metrics,
     check_prometheus_node_exporter,
+    check_external_validation_endpoint,
 ]
 
 

--- a/charts/cloudzero-agent/templates/cm.yaml
+++ b/charts/cloudzero-agent/templates/cm.yaml
@@ -146,7 +146,7 @@ data:
           follow_redirects: true
           enable_http2: true
     remote_write:
-      - url: 'https://{{ .Values.host }}/v1/container-metrics?cluster_name={{.Values.clusterName}}&cloud_account_id={{.Values.cloudAccountId | toString}}'
+      - url: 'https://{{ .Values.host }}/v1/container-metrics?cluster_name={{.Values.clusterName}}&cloud_account_id={{.Values.cloudAccountId | toString}}&region={{.Values.region}}'
         authorization:
           credentials_file: /etc/config/prometheus/secrets/value
         write_relabel_configs:

--- a/charts/cloudzero-agent/templates/deploy.yaml
+++ b/charts/cloudzero-agent/templates/deploy.yaml
@@ -41,6 +41,11 @@ spec:
               value: http://{{- if .Release.Name }}{{.Release.Name}}-{{- end }}kube-state-metrics:8080/
             - name: NODE_EXPORTER_EP_URL
               value: http://{{- if .Release.Name }}{{.Release.Name}}-{{- end }}prometheus-node-exporter:9100/
+          volumeMounts:
+            - name: cloudzero-api-key
+              mountPath: /etc/config/prometheus/secrets/
+              subPath: ""
+              readOnly: true
       containers:
         {{- if .Values.configmapReload.prometheus.enabled }}
         - name: {{ template "cloudzero-agent.name" . }}-{{ .Values.server.name }}-configmap-reload

--- a/charts/cloudzero-agent/values.schema.json
+++ b/charts/cloudzero-agent/values.schema.json
@@ -14,11 +14,15 @@
             "string",
             "integer"
         ]
+    },
+    "region": {
+        "type": "string"
     }
 },
 "required": [
     "host",
     "clusterName",
-    "cloudAccountId"
+    "cloudAccountId",
+    "region"
 ]
   }

--- a/charts/cloudzero-agent/values.yaml
+++ b/charts/cloudzero-agent/values.yaml
@@ -4,6 +4,8 @@ host: api.cloudzero.com
 cloudAccountId: null
 # -- Name of the clusters.
 clusterName: null
+# -- Region the cluster is running in.
+region: null
 # -- CloudZero API key. Required if useExistingSecret is false.
 apiKey: null
 # -- If set, the agent will use the API key in this Secret to authenticate with CloudZero.


### PR DESCRIPTION
Same as https://github.com/JonParsons11350/cloudzero-charts/pull/1

Don't look at this yet - should have been in draft



By submitting a PR to this repository, you agree to the terms within the [CloudZero Code of Conduct](https://github.com/cloudzero/template-cloudzero-open-source/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/cloudzero/template-cloudzero-open-source/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

This change adds "region" as a required input parameter. This is necessary to uniquely identity clusters in CloudZero - since the same cluster name + cloud account ID could be deployed in multiple regions, region is necessary to distinguish between the two.

### References

> Include any links supporting this change such as a:
>
> - GitHub Issue/PR number addressed or fixed
> - StackOverflow post
> - Support forum thread
> - Related pull requests/issues from other repos
>
> If there are no references, simply delete this section.

### Testing

> Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
>
> Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.
>
> Also include details of the environment this PR was developed in (language/platform/browser version).

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`