### PR TITLE
CP-19831 allow configurable KMS DNS values

### DIFF
--- a/.github/workflows/build-test-publish-image.yml
+++ b/.github/workflows/build-test-publish-image.yml
@@ -20,7 +20,8 @@ env:
   REGISTRY_PROD_ADDR: ghcr.io
   # image name should be prefixed with the repository name
   IMAGE_NAME: ${{ github.repository }}/cloudzero-agent-validator
-  
+  SKIP_VALIDATIONS: false
+
 jobs:
   # This job detects if there are any changes to allow condition testing in other jobs
   has_changes:
@@ -175,6 +176,17 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      # PRs from a fork don't have access to the secrets
+      # don't fail in this case, skip validate
+      - name: INPUT PREP - Skip validation
+        if: needs.has_changes.outputs.any_changed == 'true'
+        id: skip_validation
+        run: |
+          # Skip if secret is not defined
+          if [[ -z "${{ secrets.CZ_API_TOKEN }}" ]]; then
+            echo "SKIP_VALIDATIONS=true" >>${GITHUB_ENV}
+          fi
+
       # Install the chart using our temporary image
       - name: TEST - Install the chart
         if: needs.has_changes.outputs.any_changed == 'true'
@@ -194,6 +206,7 @@ jobs:
           echo "using image_name=${image_name}"
           echo "using image_tag=${image_tag}"
           echo "using image_digest=${image_digest}"
+          echo "skip_validation=${{ env.SKIP_VALIDATIONS }}"
   
           kubectl create namespace $NAMESPACE
           kubectl create secret -n $NAMESPACE generic api-token --from-literal=value=$CZ_API_TOKEN
@@ -207,6 +220,7 @@ jobs:
               --set=validator.image.repository=${image_name} \
               --set=validator.image.tag=${image_tag} \
               --set=validator.image.digest=${image_digest} \
+              --set=validator.image.config.skip_validations=${skip_validation} \
               --set=existingSecretName=api-token \
               --set=clusterName=$CLUSTER_NAME \
               --set=cloudAccountId=$CLOUD_ACCOUNT_ID \

--- a/.github/workflows/build-test-publish-image.yml
+++ b/.github/workflows/build-test-publish-image.yml
@@ -219,7 +219,7 @@ jobs:
             --chart-repos=prometheus-node-exporter=$PROM_CHART_REPO \
             --namespace $NAMESPACE \
             --helm-extra-set-args "\
-              --set=validator.skipValidations=${skip_validation} \
+              --set=validator.skipValidations=${{ env.SKIP_VALIDATIONS }} \
               --set=validator.image.repository=${image_name} \
               --set=validator.image.tag=${image_tag} \
               --set=validator.image.digest=${image_digest} \

--- a/.github/workflows/build-test-publish-image.yml
+++ b/.github/workflows/build-test-publish-image.yml
@@ -227,8 +227,8 @@ jobs:
               --set=clusterName=$CLUSTER_NAME \
               --set=cloudAccountId=$CLOUD_ACCOUNT_ID \
               --set=region=$REGION \
-              --set=kubeStateMetrics.enabled=true \
-              --set=prometheusNodeExporter.enabled=true"
+              --set=kube-state-metrics.enabled=true \
+              --set=prometheus-node-exporter.enabled=true"
       
       ###########################################################################
       # PRODUCTION ONLY STEPS BEYOND THIS POINT

--- a/.github/workflows/build-test-publish-image.yml
+++ b/.github/workflows/build-test-publish-image.yml
@@ -219,16 +219,16 @@ jobs:
             --chart-repos=prometheus-node-exporter=$PROM_CHART_REPO \
             --namespace $NAMESPACE \
             --helm-extra-set-args "\
+              --set=validator.skipValidations=${skip_validation} \
               --set=validator.image.repository=${image_name} \
               --set=validator.image.tag=${image_tag} \
               --set=validator.image.digest=${image_digest} \
-              --set=validator.image.config.skip_validations=${skip_validation} \
               --set=existingSecretName=api-token \
               --set=clusterName=$CLUSTER_NAME \
               --set=cloudAccountId=$CLOUD_ACCOUNT_ID \
               --set=region=$REGION \
-              --set=kube-state-metrics.enabled=true \
-              --set=prometheus-node-exporter.enabled=true"
+              --set=kubeStateMetrics.enabled=true \
+              --set=prometheusNodeExporter.enabled=true"
       
       ###########################################################################
       # PRODUCTION ONLY STEPS BEYOND THIS POINT

--- a/charts/cloudzero-agent/Chart.yaml
+++ b/charts/cloudzero-agent/Chart.yaml
@@ -11,8 +11,8 @@ dependencies:
   - name: kube-state-metrics
     version: "5.15.*"
     repository: https://prometheus-community.github.io/helm-charts
-    condition: kube-state-metrics.enabled
+    condition: kubeStateMetrics.enabled
   - name: prometheus-node-exporter
     version: "4.24.*"
     repository: https://prometheus-community.github.io/helm-charts
-    condition: prometheus-node-exporter.enabled
+    condition: prometheusNodeExporter.enabled

--- a/charts/cloudzero-agent/Chart.yaml
+++ b/charts/cloudzero-agent/Chart.yaml
@@ -11,8 +11,8 @@ dependencies:
   - name: kube-state-metrics
     version: "5.15.*"
     repository: https://prometheus-community.github.io/helm-charts
-    condition: kubeStateMetrics.enabled
+    condition: kube-state-metrics.enabled
   - name: prometheus-node-exporter
     version: "4.24.*"
     repository: https://prometheus-community.github.io/helm-charts
-    condition: prometheusNodeExporter.enabled
+    condition: prometheus-node-exporter.enabled

--- a/charts/cloudzero-agent/README.md
+++ b/charts/cloudzero-agent/README.md
@@ -62,17 +62,15 @@ This chart relies on metrics from the [kube-state-metrics](https://github.com/ku
 By default, these subcharts are disabled to allow the agent to scrape metrics from existing instances of `kube-state-metrics` and `node-exporter`. If you have an existing deployment, you need to configure the cloudzero-agent to use the existing service endpoint addresses. You can set these addresses in the `values.yaml` file as follows by defining the relative `serviceEndpoint`:
 
 ```yaml
-kubeStateMetrics:
-  enabled: false
-  serviceEndpoint: <kube-state-metrics>.<example-namespace>.svc.cluster.local:8080
-prometheusNodeExporter:
-  enabled: false
-  serviceEndpoint: <node-exporter>.<example-namespace>.svc.cluster.local:9100
+validator:
+  serviceEndpoints:
+     kubeStateMetrics: <kube-state-metrics>.<example-namespace>.svc.cluster.local:8080
+     prometheusNodeExporter: <node-exporter>.<example-namespace>.svc.cluster.local:9100
 ```
 
 > **Note:** Replace `<example-namespace>` and the service names with the ones used in your deployments.
 
-Alternatively, you can deploy them automatically by enabling the following settings:
+Alternatively, if you do not have an existing kube-state-metrics and node-exporter, you can deploy them automatically by enabling the following settings. In this case you do not need to set the `validator.serviceEndpoints.*` values:
 
 ```yaml
 kubeStateMetrics:

--- a/charts/cloudzero-agent/README.md
+++ b/charts/cloudzero-agent/README.md
@@ -56,17 +56,35 @@ kubectl create secret -n example-namespace generic example-secret-name --from-li
 The Secret can then be used by the agent by giving `example-secret-name` as the Secret name for the `existingSecretName` argument.
 
 ### Metric Exporters
-This chart uses metrics from the [kube-state-metrics](https://github.com/kubernetes/kube-state-metrics) and [node-exporter](https://github.com/prometheus/node_exporter) projects as chart dependencies. By default, these subcharts are disabled so that the agent can scrape metrics from existing instances of `kube-state-metrics` and `node-exporter`. They can optionally be enabled with the settings:
+
+This chart relies on metrics from the [kube-state-metrics](https://github.com/kubernetes/kube-state-metrics) and [node-exporter](https://github.com/prometheus/node_exporter) projects as chart dependencies.
+
+By default, these subcharts are disabled to allow the agent to scrape metrics from existing instances of `kube-state-metrics` and `node-exporter`. If you have an existing deployment, you need to configure the cloudzero-agent to use the existing service endpoint addresses. You can set these addresses in the `values.yaml` file as follows by defining the relative `serviceEndpoint`:
+
 ```yaml
-kube-state-metrics:
+kubeStateMetrics:
+  enabled: false
+  serviceEndpoint: <kube-state-metrics>.<example-namespace>.svc.cluster.local:8080
+prometheusNodeExporter:
+  enabled: false
+  serviceEndpoint: <node-exporter>.<example-namespace>.svc.cluster.local:9100
+```
+
+> **Note:** Replace `<example-namespace>` and the service names with the ones used in your deployments.
+
+Alternatively, you can deploy them automatically by enabling the following settings:
+
+```yaml
+kubeStateMetrics:
   enabled: true
-prometheus-node-exporter:
+prometheusNodeExporter:
   enabled: true
 ```
-This will deploy the required resources for metric scraping.
+
+This will deploy the necessary resources for metric scraping.
 
 ### Custom Scrape Configs
-If the chart is running *without* the `kube-state-metrics` and `prometheus-node-exporter` exporters enabled (meaning, those two exporters are deployed from some other source outside of this chart), then the scrape configs used by the underlying Prometheus agent may need to be adjusted.
+If the chart is running **_without_** the `kube-state-metrics` and `prometheus-node-exporter` exporters enabled (meaning, those two exporters are deployed from some other source outside of this chart), then the scrape configs used by the underlying Prometheus agent may need to be adjusted.
 
 As an example, the out-of-the-box scrape config in this chart attempts to find the `kube-state-metrics` and `node-exporter` exporters via an annotation on k8s Services deployed by the KSM ande node-exporter subcharts. If those subcharts were instead deployed without any annotations, and were only available via Services with the addresses `my-kube-state-metrics-service.default.svc.cluster.local:8080` and `my-node-exporter.default.svc.cluster.local:9100`, we could add the following:
 
@@ -139,6 +157,7 @@ See the `kube-state-metrics` [documentation](https://github.com/kubernetes/kube-
 
 ## Values
 
+**Manditory Values**
 | Key               | Type   | Default               | Description                                                                                                             |
 |-------------------|--------|-----------------------|-------------------------------------------------------------------------------------------------------------------------|
 | cloudAccountId    | string | `nil`                 | Account ID in AWS or Subscription ID in Azure of the account the cluster is running in.                                 |
@@ -147,6 +166,7 @@ See the `kube-state-metrics` [documentation](https://github.com/kubernetes/kube-
 | apiKey            | string | `nil`                 | The CloudZero API key to use to export metrics. Only used if `existingSecretName` is not set.                           |
 | existingSecretName| string | `nil`                 | The name of the secret that contains the CloudZero API key. Required if not providing the API key via the apiKey value. |
 | region            | string | `nil`                 | Region the cluster is running in.                                                                                       |
+
 
 
 ## Requirements

--- a/charts/cloudzero-agent/src/validate.py
+++ b/charts/cloudzero-agent/src/validate.py
@@ -96,7 +96,7 @@ def run_validations() -> Dict[str, str]:
 def must_pass(results: Dict[str, str]):
     skip = os.getenv("SKIP_VALIDATIONS", "false")
     if any(result != "success" for result in results.values()):
-        if not skip == "true":
+        if skip != "true":
             exit(1)
 
 

--- a/charts/cloudzero-agent/src/validate.py
+++ b/charts/cloudzero-agent/src/validate.py
@@ -55,8 +55,10 @@ def run_validations() -> Dict[str, str]:
 
 
 def must_pass(results: Dict[str, str]):
+    skip = os.getenv("SKIP_VALIDATIONS", "false")
     if any(result != "success" for result in results.values()):
-        exit(1)
+        if not skip == "true":
+            exit(1)
 
 
 def print_results(results: Dict[str, str]) -> None:

--- a/charts/cloudzero-agent/templates/deploy.yaml
+++ b/charts/cloudzero-agent/templates/deploy.yaml
@@ -40,14 +40,14 @@ spec:
             - name: SKIP_VALIDATIONS
               value: "{{ .Values.validator.skipValidations }}"
             - name: KMS_EP_URL
-              {{- if .Values.kubeStateMetrics.serviceEndpoint }}
-              value: http://{{ .Values.kubeStateMetrics.serviceEndpoint }}/
+              {{- if .Values.validator.serviceEndpoints.kubeStateMetrics }}
+              value: http://{{ .Values.validator.serviceEndpoints.kubeStateMetrics }}/
               {{- else }}
               value: http://{{- if .Release.Name }}{{.Release.Name}}-{{- end }}kube-state-metrics:8080/
               {{- end }}
             - name: NODE_EXPORTER_EP_URL
-              {{- if .Values.prometheusNodeExporter.serviceEndpoint }}
-              value: http://{{ .Values.prometheusNodeExporter.serviceEndpoint }}/
+              {{- if .Values.validator.serviceEndpoints.prometheusNodeExporter }}
+              value: http://{{ .Values.validator.serviceEndpoints.prometheusNodeExporter }}/
               {{- else }}
               value: http://{{- if .Release.Name }}{{.Release.Name}}-{{- end }}prometheus-node-exporter:9100/
               {{- end }}

--- a/charts/cloudzero-agent/templates/deploy.yaml
+++ b/charts/cloudzero-agent/templates/deploy.yaml
@@ -37,10 +37,30 @@ spec:
           env:
             - name: CZ_HOST
               value: {{ .Values.host }}
+            - name: SKIP_VALIDATIONS
+              value: "{{ .Values.validator.skip_validations }}"
             - name: KMS_EP_URL
+              {{- if index .Values "kube-state-metrics.dns_name" }}
+              {{- if index .Values "kube-state-metrics.port" }}
+              value: http://{{ index .Values "kube-state-metrics.dns_name" }}:{{ index .Values "kube-state-metrics.port" }}/
+              {{- else }}
+              value: http://{{ index .Values "kube-state-metrics.dns_name" }}:8080/
+              {{- end }}
+              {{- else }}
               value: http://{{- if .Release.Name }}{{.Release.Name}}-{{- end }}kube-state-metrics:8080/
+              {{- end }}
             - name: NODE_EXPORTER_EP_URL
+              {{- if index .Values "prometheus-node-exporter.dns_name" }}
+              {{- if index .Values "prometheus-node-exporter.port" }}
+              value: http://{{ index .Values "prometheus-node-exporter.dns_name" }}:{{ index .Values "prometheus-node-exporter.port" }}/
+              {{- else }}
+              value: http://{{ index .Values "prometheus-node-exporter.dns_name" }}:9100/
+              {{- end }}
+              {{- else }}
               value: http://{{- if .Release.Name }}{{.Release.Name}}-{{- end }}prometheus-node-exporter:9100/
+              {{- end }}
+            - name: SKIP_VALIDATIONS
+              value: "{{ .Values.validator.skip_validations }}"
       containers:
         {{- if .Values.configmapReload.prometheus.enabled }}
         - name: {{ template "cloudzero-agent.name" . }}-{{ .Values.server.name }}-configmap-reload

--- a/charts/cloudzero-agent/templates/deploy.yaml
+++ b/charts/cloudzero-agent/templates/deploy.yaml
@@ -38,7 +38,7 @@ spec:
             - name: CZ_HOST
               value: {{ .Values.host }}
             - name: SKIP_VALIDATIONS
-              value: "{{ .Values.validator.skip_validations }}"
+              value: {{ .Values.validator.config.skip_validations }}
             - name: KMS_EP_URL
               {{- if index .Values "kube-state-metrics.dns_name" }}
               {{- if index .Values "kube-state-metrics.port" }}

--- a/charts/cloudzero-agent/templates/deploy.yaml
+++ b/charts/cloudzero-agent/templates/deploy.yaml
@@ -38,7 +38,7 @@ spec:
             - name: CZ_HOST
               value: {{ .Values.host }}
             - name: SKIP_VALIDATIONS
-              value: {{ .Values.validator.config.skip_validations }}
+              value: {{ .Values.validator.image.config.skip_validations }}
             - name: KMS_EP_URL
               {{- if index .Values "kube-state-metrics.dns_name" }}
               {{- if index .Values "kube-state-metrics.port" }}

--- a/charts/cloudzero-agent/templates/deploy.yaml
+++ b/charts/cloudzero-agent/templates/deploy.yaml
@@ -38,29 +38,21 @@ spec:
             - name: CZ_HOST
               value: {{ .Values.host }}
             - name: SKIP_VALIDATIONS
-              value: {{ .Values.validator.image.config.skip_validations }}
+              value: "{{ .Values.validator.skipValidations }}"
             - name: KMS_EP_URL
-              {{- if index .Values "kube-state-metrics.dns_name" }}
-              {{- if index .Values "kube-state-metrics.port" }}
-              value: http://{{ index .Values "kube-state-metrics.dns_name" }}:{{ index .Values "kube-state-metrics.port" }}/
-              {{- else }}
-              value: http://{{ index .Values "kube-state-metrics.dns_name" }}:8080/
-              {{- end }}
+              {{- if .Values.kubeStateMetrics.serviceEndpoint }}
+              value: http://{{ .Values.kubeStateMetrics.serviceEndpoint }}/
               {{- else }}
               value: http://{{- if .Release.Name }}{{.Release.Name}}-{{- end }}kube-state-metrics:8080/
               {{- end }}
             - name: NODE_EXPORTER_EP_URL
-              {{- if index .Values "prometheus-node-exporter.dns_name" }}
-              {{- if index .Values "prometheus-node-exporter.port" }}
-              value: http://{{ index .Values "prometheus-node-exporter.dns_name" }}:{{ index .Values "prometheus-node-exporter.port" }}/
-              {{- else }}
-              value: http://{{ index .Values "prometheus-node-exporter.dns_name" }}:9100/
-              {{- end }}
+              {{- if .Values.prometheusNodeExporter.serviceEndpoint }}
+              value: http://{{ .Values.prometheusNodeExporter.serviceEndpoint }}/
               {{- else }}
               value: http://{{- if .Release.Name }}{{.Release.Name}}-{{- end }}prometheus-node-exporter:9100/
               {{- end }}
-            - name: SKIP_VALIDATIONS
-              value: "{{ .Values.validator.skip_validations }}"
+            - name: REGION
+              value: {{ .Values.region }}
           volumeMounts:
             - name: cloudzero-api-key
               mountPath: /etc/config/prometheus/secrets/

--- a/charts/cloudzero-agent/values.yaml
+++ b/charts/cloudzero-agent/values.yaml
@@ -43,14 +43,12 @@ prometheusConfig:
     additionalScrapeJobs: []
 
 
-kube-state-metrics:
+kubeStateMetrics:
   enabled: false
-  dns_name: kube-state-metrics
-  port: 8080
-prometheus-node-exporter:
+  serviceEndpoint:
+prometheusNodeExporter:
   enabled: false
-  dns_name: prometheus-node-exporter
-  port: 9100
+  serviceEndpoint:
 
 # -- Annotations to be added to the Secret, if the chart is configured to create one
 secretAnnotations: {}
@@ -58,14 +56,14 @@ imagePullSecrets: []
 
 # environment validator image allows for CI to use a different image in testing
 validator:
+  # -- Flag to skip validator failure if unable to connect to the CloudZero API.
+  skipValidations: false
   name: env-validator
   image:
-    repository: ghcr.io/cloudzero/cloudzero-charts/cloudzero-agent-validator
-    tag: latest
+    repository: ghcr.io/josephbarnett/cloudzero-charts/cloudzero-agent-validator
+    tag: test
     digest:
     pullPolicy: Always
-    config:
-      skip_validations: false
 
 server:
   name: server
@@ -129,3 +127,4 @@ configmapReload:
 
     containerSecurityContext: {}
     resources: {}
+

--- a/charts/cloudzero-agent/values.yaml
+++ b/charts/cloudzero-agent/values.yaml
@@ -60,7 +60,7 @@ validator:
   skipValidations: false
   name: env-validator
   image:
-    repository: ghcr.io/Cloudzero/cloudzero-charts/cloudzero-agent-validator
+    repository: ghcr.io/cloudzero/cloudzero-charts/cloudzero-agent-validator
     tag: latest
     digest:
     pullPolicy: Always

--- a/charts/cloudzero-agent/values.yaml
+++ b/charts/cloudzero-agent/values.yaml
@@ -127,4 +127,3 @@ configmapReload:
 
     containerSecurityContext: {}
     resources: {}
-

--- a/charts/cloudzero-agent/values.yaml
+++ b/charts/cloudzero-agent/values.yaml
@@ -60,8 +60,8 @@ validator:
   skipValidations: false
   name: env-validator
   image:
-    repository: ghcr.io/josephbarnett/cloudzero-charts/cloudzero-agent-validator
-    tag: test
+    repository: ghcr.io/Cloudzero/cloudzero-charts/cloudzero-agent-validator
+    tag: latest
     digest:
     pullPolicy: Always
 

--- a/charts/cloudzero-agent/values.yaml
+++ b/charts/cloudzero-agent/values.yaml
@@ -43,8 +43,12 @@ prometheusConfig:
 
 kube-state-metrics:
   enabled: false
+  dns_name: kube-state-metrics
+  port: 8080
 prometheus-node-exporter:
   enabled: false
+  dns_name: prometheus-node-exporter
+  port: 9100
 
 # -- Annotations to be added to the Secret, if the chart is configured to create one
 secretAnnotations: {}
@@ -58,6 +62,8 @@ validator:
     tag: latest
     digest:
     pullPolicy: Always
+    config:
+      skip_validations: false
 
 server:
   name: server

--- a/charts/cloudzero-agent/values.yaml
+++ b/charts/cloudzero-agent/values.yaml
@@ -45,10 +45,10 @@ prometheusConfig:
 
 kube-state-metrics:
   enabled: false
-  
+
 prometheus-node-exporter:
   enabled: false
-  
+
 # -- Annotations to be added to the Secret, if the chart is configured to create one
 secretAnnotations: {}
 imagePullSecrets: []
@@ -56,8 +56,8 @@ imagePullSecrets: []
 # environment validator image allows for CI to use a different image in testing
 validator:
   serviceEndpoints:
-     kubeStateMetrics:
-     prometheusNodeExporter:
+    kubeStateMetrics:
+    prometheusNodeExporter:
   # -- Flag to skip validator failure if unable to connect to the CloudZero API.
   skipValidations: false
   name: env-validator

--- a/charts/cloudzero-agent/values.yaml
+++ b/charts/cloudzero-agent/values.yaml
@@ -43,19 +43,21 @@ prometheusConfig:
     additionalScrapeJobs: []
 
 
-kubeStateMetrics:
+kube-state-metrics:
   enabled: false
-  serviceEndpoint:
-prometheusNodeExporter:
+  
+prometheus-node-exporter:
   enabled: false
-  serviceEndpoint:
-
+  
 # -- Annotations to be added to the Secret, if the chart is configured to create one
 secretAnnotations: {}
 imagePullSecrets: []
 
 # environment validator image allows for CI to use a different image in testing
 validator:
+  serviceEndpoints:
+     kubeStateMetrics:
+     prometheusNodeExporter:
   # -- Flag to skip validator failure if unable to connect to the CloudZero API.
   skipValidations: false
   name: env-validator


### PR DESCRIPTION
### Description

* Add override to values.yaml when user has KMS/NodeExporter deployed already (ie. local DNS value to use with validator script)
* Add `skip_validations` flag to allow PRs from forks to merge when `secrets` are not set
* Refactor `kms` and `pne` yaml blocks to avoid complicated helm `index .Values` logic (should be camelcase)
* update readme for configuring `serviceEndpoint` for KMS and NodeExporter
### Testing
- [x] Manual tested existing kms/ne deployment (pass both dns & port)
- [x]  Manual tested existing kms/ne deployment (pass both dns only)
- [x]  Manual tested deployment with kms/ne
- [x]  Manual tested CI/CD workflows
- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`