### PR TITLE
CP-19620: reduce amount of ingested metrics and metric labels

### DIFF
--- a/charts/cloudzero-agent/CHANGELOG.md
+++ b/charts/cloudzero-agent/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.10]
+
+### Added
+- Resource consumption is reduced by limiting ingestion of unneeded metrics and metric labels
+
 ## [0.0.9]
 
 ### Added

--- a/charts/cloudzero-agent/templates/_helpers.tpl
+++ b/charts/cloudzero-agent/templates/_helpers.tpl
@@ -114,8 +114,19 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{/*
 Combine metric lists
 */}}
-{{- define "chartname.combineMetrics" -}}
+{{- define "cloudzero-agent.combineMetrics" -}}
 {{- $total := concat .Values.kubeMetrics .Values.containerMetrics -}}
+{{- $result := join "|" $total -}}
+{{- $result -}}
+{{- end -}}
+
+{{/*
+Required metric labels
+*/}}
+{{- define "cloudzero-agent.requiredMetricLabels" -}}
+{{- $requiredSpecialMetricLabels := tuple "_.*" "label_.*" }}
+{{- $requiredCZMetricLabels := tuple "board_asset_tag" "container" "created_by_kind" "created_by_name" "image" "instance" "name" "namespace" "node" "node_kubernetes_io_instance_type" "pod" "product_name" "provider_id" "resource" "unit" "uid" -}}
+{{- $total := concat .Values.additionalMetricLabels $requiredCZMetricLabels $requiredSpecialMetricLabels -}}
 {{- $result := join "|" $total -}}
 {{- $result -}}
 {{- end -}}

--- a/charts/cloudzero-agent/templates/cm.yaml
+++ b/charts/cloudzero-agent/templates/cm.yaml
@@ -88,6 +88,12 @@ data:
           target_label: node
           replacement: $1
           action: replace
+        metric_relabel_configs:
+        - source_labels: [__name__]
+          regex: "^({{ join "|" .Values.kubeMetrics }})$"
+          action: keep
+        - action: labelkeep
+          regex: "^({{ include "cloudzero-agent.requiredMetricLabels" . }})$"
         kubernetes_sd_configs:
         - role: endpoints
           kubeconfig_file: ""
@@ -135,8 +141,8 @@ data:
           target_label: node
           action: replace
         metric_relabel_configs:
-        - action: labeldrop
-          regex: instance
+        - action: labelkeep
+          regex: "^({{ include "cloudzero-agent.requiredMetricLabels" . }})$"
         - source_labels: [__name__]
           regex: "^({{ join "|" .Values.containerMetrics }})$"
           action: keep
@@ -156,7 +162,7 @@ data:
           credentials_file: /etc/config/prometheus/secrets/value
         write_relabel_configs:
           - source_labels: [__name__]
-            regex: "^({{ include "chartname.combineMetrics" . }})$"
+            regex: "^({{ include "cloudzero-agent.combineMetrics" . }})$"
             action: keep
         metadata_config:
           send: false

--- a/charts/cloudzero-agent/values.yaml
+++ b/charts/cloudzero-agent/values.yaml
@@ -20,13 +20,15 @@ kubeMetrics:
   - kube_pod_container_resource_requests
   - kube_pod_labels
   - kube_pod_info
-  - node_cpu_seconds_total
   - node_dmi_info
 containerMetrics:
   - container_cpu_usage_seconds_total
   - container_memory_working_set_bytes
   - container_network_receive_bytes_total
   - container_network_transmit_bytes_total
+
+# -- Any items added to this array will be added to the metrics that are sent to CloudZero, in addition to the minimal labels that CloudZero requires.
+additionalMetricLabels: []
 
 prometheusConfig:
   configMapNameOverride: ''


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [CloudZero Code of Conduct](https://github.com/cloudzero/template-cloudzero-open-source/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/cloudzero/template-cloudzero-open-source/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

we scrape a fairly large amount of metrics and metric labels that we don't really need, which increases resource usage.

### Testing

1. performance - in a load test, memory was reduced by ~50%, CPU usage unchanged
2. functional - asserted standard test workloads produced the same container data output via standard pipline

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`