### PR TITLE
[CP-19969] github action for main branch should pull before pushing

### DIFF
--- a/.github/workflows/build-and-publish-chart.yml
+++ b/.github/workflows/build-and-publish-chart.yml
@@ -42,7 +42,7 @@ jobs:
         author_name: "GitHub Actions Bot"
         author_email: "actions@github.com"
         message: "Update Chart.yaml to version ${{ env.NEW_VERSION }}"
-        path: "charts/cloudzero-agent/Chart.yaml"      
+        pull: '--rebase'
 
     - name: Upload Chart as Artifact
       uses: actions/upload-artifact@v2
@@ -54,24 +54,25 @@ jobs:
       uses: actions/checkout@v2
       with:
         ref: gh-pages
-      
+
     - name: Download Chart Artifact
       uses: actions/download-artifact@v2
       with:
         name: agent-chart
         path: .
 
-    - name: Update Index 
+    - name: Update Index
       run: |
         helm repo index --url https://cloudzero.github.io/cloudzero-charts .
-  
+
     - name: Commit and Push changes
       uses: EndBug/add-and-commit@v9
       with:
         author_name: Clouzero Bot
         author_email: ops@cloudzero.com
-        message: 'Commit for ${{ env.NEW_VERSION }}' 
+        message: 'Commit for ${{ env.NEW_VERSION }}'
         add: '*'
+        pull: '--rebase'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [CloudZero Code of Conduct](https://github.com/cloudzero/template-cloudzero-open-source/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/cloudzero/template-cloudzero-open-source/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

we can get into a weird state with our github actions if they fail halfway through for whatever reason. this makes sure that we are pushing on top of the latest commit

### References

see documentation here https://github.com/EndBug/add-and-commit?tab=readme-ov-file#inputs


- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`