### PR TITLE
[CP-19969] do not pull for gh pages update

### DIFF
--- a/.github/workflows/build-and-publish-chart.yml
+++ b/.github/workflows/build-and-publish-chart.yml
@@ -72,7 +72,6 @@ jobs:
         author_email: ops@cloudzero.com
         message: 'Commit for ${{ env.NEW_VERSION }}'
         add: '*'
-        pull: '--rebase'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/charts/cloudzero-agent/Chart.yaml
+++ b/charts/cloudzero-agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cloudzero-agent
 description: A chart for using Prometheus in agent mode to send cluster metrics to the CloudZero platform.
 type: application
-version: 0.0.9
+version: 0.0.10
 maintainers:
   - name: CloudZero
     email: support@cloudzero.com


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [CloudZero Code of Conduct](https://github.com/cloudzero/template-cloudzero-open-source/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/cloudzero/template-cloudzero-open-source/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

adding the `pull --rebase` to the second commit caused issues. reverting it here
### Testing

I tested this by creating replica branches of main and gh-pages and making sure that the same change worked: https://github.com/Cloudzero/cloudzero-charts/actions/runs/9862680239/job/27233806359

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`