### PR TITLE
Cp 20006 improve cloudzero charts release workflow

### DIFF
--- a/.github/workflows/build-and-publish-chart.yml
+++ b/.github/workflows/build-and-publish-chart.yml
@@ -1,86 +1,107 @@
 name: build-and-publish-chart
 
 on:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
 
 jobs:
   build-and-publish-chart:
+    permissions:
+      contents: 'write'
+      packages: 'write'
+      id-token: write
+      actions: 'read'
     runs-on: ubuntu-latest
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v3
+    steps: 
 
-    - name: Install Helm
-      uses: azure/setup-helm@v3
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}   # checkout the correct branch name
+          fetch-depth: 0                # fetch the whole repo history
 
-    - name: Build Dependencies
-      run: |
-        helm dependency update charts/cloudzero-agent/
+      - name: Fetch all branches
+        run: git fetch --all
 
-    - name: Update Version
-      id: version
-      uses: flatherskevin/semver-action@v1
-      with:
-        incrementLevel: patch
-        source: tags
+      - name: Checkout develop branch
+        run: git checkout develop
 
-    - name: Update Chart Version
-      run: |
-        VERSION_LINE=$(awk '/version:/ && !done {print NR; done=1}' charts/cloudzero-agent/Chart.yaml)
-        sed -i ''$VERSION_LINE's/.*/version: ${{ steps.version.outputs.nextVersion }}/' charts/cloudzero-agent/Chart.yaml
-        echo "NEW_VERSION=${{ steps.version.outputs.nextVersion }}" >> $GITHUB_ENV
+      - name: Rebase develop branch
+        run: git pull --rebase origin develop
 
-    - name: Package Chart
-      run: |
-        helm package charts/cloudzero-agent/ --destination .deploy
+      - name: Checkout main branch
+        run: git checkout main
 
-    - name: Commit updated Chart.yaml
-      uses: EndBug/add-and-commit@v9
-      with:
-        author_name: "GitHub Actions Bot"
-        author_email: "actions@github.com"
-        message: "Update Chart.yaml to version ${{ env.NEW_VERSION }}"
-        pull: '--rebase'
+      - name: Rebase main branch
+        run: git pull --rebase origin main
 
-    - name: Upload Chart as Artifact
-      uses: actions/upload-artifact@v2
-      with:
-        name: agent-chart
-        path: .deploy/cloudzero-agent-${{ env.NEW_VERSION }}.tgz
+      - name: Merge develop into main
+        run: git merge --ff-only develop
 
-    - name: Checkout GH Pages
-      uses: actions/checkout@v2
-      with:
-        ref: gh-pages
+      - name: Install Helm
+        uses: azure/setup-helm@v3
 
-    - name: Download Chart Artifact
-      uses: actions/download-artifact@v2
-      with:
-        name: agent-chart
-        path: .
+      - name: Build Dependencies
+        run: |
+          helm dependency update charts/cloudzero-agent/
 
-    - name: Update Index
-      run: |
-        helm repo index --url https://cloudzero.github.io/cloudzero-charts .
+      - name: Update Version
+        id: version
+        uses: flatherskevin/semver-action@v1
+        with:
+          incrementLevel: patch
+          source: tags
 
-    - name: Commit and Push changes
-      uses: EndBug/add-and-commit@v9
-      with:
-        author_name: Clouzero Bot
-        author_email: ops@cloudzero.com
-        message: 'Commit for ${{ env.NEW_VERSION }}'
-        add: '*'
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Update Chart Version
+        run: |
+          VERSION_LINE=$(awk '/version:/ && !done {print NR; done=1}' charts/cloudzero-agent/Chart.yaml)
+          sed -i ''$VERSION_LINE's/.*/version: ${{ steps.version.outputs.nextVersion }}/' charts/cloudzero-agent/Chart.yaml
+          echo "NEW_VERSION=${{ steps.version.outputs.nextVersion }}" >> $GITHUB_ENV
 
-    - name: Create Release
-      uses: softprops/action-gh-release@v2
-      with:
-        name: ${{ steps.version.outputs.nextVersion }}
-        tag_name: ${{ steps.version.outputs.nextVersion }}
-        files: cloudzero-agent-${{ env.NEW_VERSION }}.tgz
-        make_latest: true
+      - name: Package Chart
+        run: |
+          helm package charts/cloudzero-agent/ --destination .deploy
 
+      - name: Commit updated Chart.yaml
+        run: |
+          git add .
+          git commit -m "Update Chart.yaml to version ${{ env.NEW_VERSION }}"
+          git push origin main
 
+      - name: Upload Chart as Artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: agent-chart
+          path: .deploy/cloudzero-agent-${{ env.NEW_VERSION }}.tgz
+
+      - name: Checkout GH Pages
+        uses: actions/checkout@v2
+        with:
+          ref: gh-pages
+
+      - name: Download Chart Artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: agent-chart
+          path: .
+
+      - name: Update Index
+        run: |
+          helm repo index --url https://cloudzero.github.io/cloudzero-charts .
+
+      - name: Commit and Push changes
+        uses: EndBug/add-and-commit@v9
+        with:
+          author_name: Clouzero Bot
+          author_email: ops@cloudzero.com
+          message: 'Commit for ${{ env.NEW_VERSION }}'
+          add: '*'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: ${{ steps.version.outputs.nextVersion }}
+          tag_name: ${{ steps.version.outputs.nextVersion }}
+          files: cloudzero-agent-${{ env.NEW_VERSION }}.tgz
+          make_latest: true

--- a/.github/workflows/build-and-publish-chart.yml
+++ b/.github/workflows/build-and-publish-chart.yml
@@ -19,6 +19,11 @@ jobs:
           ref: ${{ github.head_ref }}   # checkout the correct branch name
           fetch-depth: 0                # fetch the whole repo history
 
+      - name: Set up Git
+        run: |
+          git config --local user.email "ops@cloudzero.com"
+          git config --local user.name "Automated CZ Release"
+
       - name: Fetch all branches
         run: git fetch --all
 
@@ -69,6 +74,8 @@ jobs:
 
       - name: Upload Chart as Artifact
         uses: actions/upload-artifact@v2
+        env:
+          ACTIONS_RUNTIME_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           name: agent-chart
           path: .deploy/cloudzero-agent-${{ env.NEW_VERSION }}.tgz

--- a/.github/workflows/build-and-publish-chart.yml
+++ b/.github/workflows/build-and-publish-chart.yml
@@ -1,5 +1,6 @@
-name: build-and-publish-chart
+name: Manual Release Chart
 
+# manual trigger only
 on:
   workflow_dispatch:
 
@@ -74,8 +75,6 @@ jobs:
 
       - name: Upload Chart as Artifact
         uses: actions/upload-artifact@v2
-        env:
-          ACTIONS_RUNTIME_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           name: agent-chart
           path: .deploy/cloudzero-agent-${{ env.NEW_VERSION }}.tgz

--- a/.github/workflows/build-and-publish-chart.yml
+++ b/.github/workflows/build-and-publish-chart.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref }}   # checkout the correct branch name
+          ref: main
           fetch-depth: 0                # fetch the whole repo history
 
       - name: Set up Git
@@ -80,9 +80,10 @@ jobs:
           path: .deploy/cloudzero-agent-${{ env.NEW_VERSION }}.tgz
 
       - name: Checkout GH Pages
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           ref: gh-pages
+          fetch-depth: 0                # fetch the whole repo history
 
       - name: Download Chart Artifact
         uses: actions/download-artifact@v2
@@ -94,15 +95,12 @@ jobs:
         run: |
           helm repo index --url https://cloudzero.github.io/cloudzero-charts .
 
-      - name: Commit and Push changes
-        uses: EndBug/add-and-commit@v9
-        with:
-          author_name: Clouzero Bot
-          author_email: ops@cloudzero.com
-          message: 'Commit for ${{ env.NEW_VERSION }}'
-          add: '*'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Commit and Push gh-pages changes
+        run: |
+          git add .
+          git commit -m "Commit for ${{ env.NEW_VERSION }}"
+          git push origin gh-pages
 
       - name: Create Release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
### Description

Improved release workflow to do all the things.


### Testing

- [x] This change was tested using `act`

```
act -j build-and-publish-chart  -a $GH_USER --secret GITHUB_TOKEN=$GH_PAT
```
Results

![Screenshot 2024-07-10 at 1 15 02 PM](https://github.com/Cloudzero/cloudzero-charts/assets/3170997/224dc771-8293-451d-9b1d-50434c6c7a5a)


### Checklist

- [x] I have added documentation for new/changed functionality in this PR
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`