### PR TITLE
CP 20053 fix chart release workflow to use correct version in packaging

### DIFF
--- a/.github/workflows/build-and-publish-chart.yml
+++ b/.github/workflows/build-and-publish-chart.yml
@@ -80,7 +80,7 @@ jobs:
         id: get_changes
         run: |
           FROM=$(git show-ref --abbrev=7 --tags | grep "${{steps.version.outputs.currentVersion }}" | cut -f1 -d' ')
-          TO=$(git show-ref --abbrev=7 --tags | grep "${{ steps.version.outputs.nextVersion }}" | cut -f1 -d' ')
+          TO=$(git rev-parse --short HEAD)
           CHANGES=$(git log ${FROM}..${TO} --oneline)
           echo "::set-output name=changes::${CHANGES}"
 

--- a/.github/workflows/build-and-publish-chart.yml
+++ b/.github/workflows/build-and-publish-chart.yml
@@ -50,24 +50,19 @@ jobs:
         run: |
           helm dependency update charts/cloudzero-agent/
 
-      - name: 'Get Previous tag'
-        id: previoustag
-        uses: "WyriHaximus/github-action-get-previous-tag@v1"
-        env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-
-      - name: 'Get next minor version'
-        id: nexttag
-        uses: "WyriHaximus/github-action-next-semvers@v1"
+      # This only gets versions - no actual changes are made to github
+      - name: Get Github Tag Version
+        id: version
+        uses: flatherskevin/semver-action@v1
         with:
-          version: ${{ steps.previoustag.outputs.tag }}
-
+          incrementLevel: patch
+          source: tags
       
       - name: Update Chart Version
         run: |
           VERSION_LINE=$(awk '/version:/ && !done {print NR; done=1}' charts/cloudzero-agent/Chart.yaml)
-          sed -i ''$VERSION_LINE's/.*/version: ${{ steps.nexttag.outputs.patch }}/' charts/cloudzero-agent/Chart.yaml
-          echo "NEW_VERSION=${{ steps.nexttag.outputs.patch }}" >> $GITHUB_ENV
+          sed -i ''$VERSION_LINE's/.*/version: ${{ steps.version.outputs.nextVersion }}/' charts/cloudzero-agent/Chart.yaml
+          echo "NEW_VERSION=${{ steps.version.outputs.nextVersion }}" >> $GITHUB_ENV
 
       - name: Package Chart
         run: |
@@ -78,14 +73,16 @@ jobs:
           git add .
           git commit -m "Update Chart.yaml to version ${{ env.NEW_VERSION }}"
           git push origin main
+          COMMIT_HASH=$(git rev-parse HEAD)
+          echo "COMMIT_HASH=${COMMIT_HASH}" >> $GITHUB_ENV
 
-      # This must happen after changes to the main branch
-      - name: Create the Github Tag Version
-        id: version
-        uses: flatherskevin/semver-action@v1
-        with:
-          incrementLevel: patch
-          source: tags
+      - name: Generate Change Log
+        id: get_changes
+        run: |
+          FROM=$(git show-ref --abbrev=7 --tags | grep "${{steps.version.outputs.currentVersion }}" | cut -f1 -d' ')
+          TO=$(git show-ref --abbrev=7 --tags | grep "${{ steps.version.outputs.nextVersion }}" | cut -f1 -d' ')
+          CHANGES=$(git log ${FROM}..${TO} --oneline)
+          echo "::set-output name=changes::${CHANGES}"
 
       - name: Upload Chart as Artifact
         uses: actions/upload-artifact@v2
@@ -114,6 +111,7 @@ jobs:
           git add .
           git commit -m "Commit for ${{ env.NEW_VERSION }}"
           git push origin gh-pages
+          # Get the latest commit hash
 
       - name: Create Release
         uses: softprops/action-gh-release@v2
@@ -122,3 +120,84 @@ jobs:
           tag_name: ${{ steps.version.outputs.nextVersion }}
           files: cloudzero-agent-${{ env.NEW_VERSION }}.tgz
           make_latest: true
+          target_commitish: ${{ env.COMMIT_HASH }}
+          body: |
+            # Release ${{ steps.version.outputs.nextVersion }} Changes
+
+            ${{ steps.get_changes.outputs.changes }}
+
+            # Installation 
+            
+            ## 1. Add the Helm Repository
+
+            ```console
+            helm repo add cloudzero https://cloudzero.github.io/cloudzero-charts
+            helm repo update
+            ```
+
+            ## 2. Install Helm Chart
+
+            The chart can be installed directly with Helm or any other common Kubernetes deployment tools.
+
+            If installing with Helm directly, the following command will install the chart:
+            ```console
+            helm install <RELEASE_NAME> cloudzero/cloudzero-agent \
+                --set existingSecretName=<NAME_OF_SECRET> \
+                --set clusterName=<CLUSTER_NAME> \
+                --set cloudAccountId=<CLOUD_ACCOUNT_ID> \
+                --set region=<REGION>
+            ```
+
+            Alternatively if you are updating an existing installation, you can upgrade the chart with:
+            ```console
+            helm upgrade <RELEASE_NAME> cloudzero/cloudzero-agent \
+                --set existingSecretName=<NAME_OF_SECRET> \
+                --set clusterName=<CLUSTER_NAME> \
+                --set cloudAccountId=<CLOUD_ACCOUNT_ID> \
+                --set region=<REGION>
+            ```
+
+            ### Secret Management
+
+            The chart requires a CloudZero API key in order to send metric data to the CloudZero platform. Admins can retrieve API keys [here](https://app.cloudzero.com/organization/api-keys).
+
+            The Deployment running Prometheus ingests the API key via a Secret; this Secret can be supplied as an existing secret (default), or created by the chart. Both methods will require the API key retrieved from the CloudZero platform.
+
+            If using a Secret external to this chart for the API key, ensure the Secret is created in the same namespace as the chart and that the Secret data follows the format:
+
+            ```yaml
+            data:
+              value: <API_KEY>
+            ```
+
+            For example, the Secret could be created with:
+            ```bash
+            kubectl create secret -n example-namespace generic example-secret-name --from-literal=value=<example-api-key-value>
+            ```
+            The Secret can then be used by the agent by giving `example-secret-name` as the Secret name for the `existingSecretName` argument.
+
+            ### Metric Exporters
+
+            This chart relies on metrics from the [kube-state-metrics](https://github.com/kubernetes/kube-state-metrics) and [node-exporter](https://github.com/prometheus/node_exporter) projects as chart dependencies.
+
+            By default, these subcharts are disabled to allow the agent to scrape metrics from existing instances of `kube-state-metrics` and `node-exporter`. If you have an existing deployment, you need to configure the cloudzero-agent to use the existing service endpoint addresses. You can set these addresses in the `values.yaml` file as follows by defining the relative `serviceEndpoint`:
+
+            ```yaml
+            validator:
+              serviceEndpoints:
+                kubeStateMetrics: <kube-state-metrics>.<example-namespace>.svc.cluster.local:8080
+                prometheusNodeExporter: <node-exporter>.<example-namespace>.svc.cluster.local:9100
+            ```
+
+            > **Note:** Replace `<example-namespace>` and the service names with the ones used in your deployments.
+
+            Alternatively, if you do not have an existing kube-state-metrics and node-exporter, you can deploy them automatically by enabling the following settings. In this case you do not need to set the `validator.serviceEndpoints.*` values:
+
+            ```yaml
+            kube-state-metrics:
+              enabled: true
+            prometheus-node-exporter:
+              enabled: true
+            ```
+
+


### PR DESCRIPTION
### Description

This fixes an error occurring during the release workflow process which was not creating the tag based on the HEAD of `main`. 

Additionally this adds a change log to the release creation.

### Testing

Tested using act (however only so much testing can be done) - it must run in CI
```
 git push --set-upstream origin CP-20053-chart-release-using-wrong-version-in-package
 ```