### PR TITLE
CP-20053: ensure we have an easy to ID version on develop branch

### DIFF
--- a/charts/cloudzero-agent/Chart.yaml
+++ b/charts/cloudzero-agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cloudzero-agent
 description: A chart for using Prometheus in agent mode to send cluster metrics to the CloudZero platform.
 type: application
-version: 0.0.10
+version: 0.0.0-dev
 maintainers:
   - name: CloudZero
     email: support@cloudzero.com


### PR DESCRIPTION
### Description

The validator will pull in the `Chart Version` when a deployment occurs. It would be valuable to have a `dirty default` version on `develop` branch to ensure we can identify when a user deployed from source on `develop` branch versus from a tag.

This is valuable because develop is intended to be always moving, and partial changes which may not be ready for a release may be present making it hard to debug failures at the customer site.

Thus `0.0.0-dev` would tell us we are dealing with a development branch deployment in the telemetry sent from the validator.

Note - this value is overwritten by the actual release version in the release workflow

### References

### Testing

N/A

