### PR TITLE
[CP-20166] update docs to help the user pass cloudAccountId as a string

### DIFF
--- a/.github/workflows/build-and-publish-chart.yml
+++ b/.github/workflows/build-and-publish-chart.yml
@@ -17,7 +17,7 @@ jobs:
       id-token: write
       actions: 'read'
     runs-on: ubuntu-latest
-    steps: 
+    steps:
 
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -137,9 +137,7 @@ jobs:
 
             ${{ steps.get_changes.outputs.changes }}
 
-            
+
             # Installation Instructions
 
             [Please follow the Installation Instructions provided in this releases README](https://github.com/Cloudzero/cloudzero-charts/blob/${{ env.NEW_VERSION }}/charts/cloudzero-agent/README.md).
-            
-            

--- a/charts/cloudzero-agent/README.md
+++ b/charts/cloudzero-agent/README.md
@@ -33,7 +33,7 @@ If installing with Helm directly, the following command will install the chart:
 helm install <RELEASE_NAME> cloudzero/cloudzero-agent \
     --set existingSecretName=<NAME_OF_SECRET> \
     --set clusterName=<CLUSTER_NAME> \
-    --set cloudAccountId=<CLOUD_ACCOUNT_ID> \
+    --set-string cloudAccountId=<CLOUD_ACCOUNT_ID> \
     --set region=<REGION>
 ```
 

--- a/charts/cloudzero-agent/README.md
+++ b/charts/cloudzero-agent/README.md
@@ -43,7 +43,7 @@ Alternatively if you are updating an existing installation, you can upgrade the 
 helm upgrade <RELEASE_NAME> cloudzero/cloudzero-agent \
     --set existingSecretName=<NAME_OF_SECRET> \
     --set clusterName=<CLUSTER_NAME> \
-    --set cloudAccountId=<CLOUD_ACCOUNT_ID> \
+    --set-string cloudAccountId=<CLOUD_ACCOUNT_ID> \
     --set region=<REGION>
 ```
 
@@ -72,7 +72,7 @@ You can use the `--values` (or short form `-f`) flag in your Helm commands to ov
 helm install <RELEASE_NAME> cloudzero/cloudzero-agent \
     --set existingSecretName=<NAME_OF_SECRET> \
     --set clusterName=<CLUSTER_NAME> \
-    --set cloudAccountId=<CLOUD_ACCOUNT_ID> \
+    --set-string cloudAccountId=<CLOUD_ACCOUNT_ID> \
     --set region=<REGION> \
     -f values-override.yaml
 ```
@@ -89,7 +89,7 @@ You can use the `--set` flag in Helm commands to directly set or override specif
 helm install <RELEASE_NAME> cloudzero/cloudzero-agent \
     --set existingSecretName=<NAME_OF_SECRET> \
     --set clusterName=<CLUSTER_NAME> \
-    --set cloudAccountId=<CLOUD_ACCOUNT_ID> \
+    --set-string cloudAccountId=<CLOUD_ACCOUNT_ID> \
     --set region=<REGION> \
     --set server.resources.limits.memory=2048Mi \
     -f values-override.yaml


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [CloudZero Code of Conduct](https://github.com/cloudzero/template-cloudzero-open-source/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/cloudzero/template-cloudzero-open-source/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

[we recently started requiring](https://github.com/Cloudzero/cloudzero-charts/commit/6eb776b7293e3ba2ae9345998f40c15e5fcab34a) that `cloudAccountId` be passed in as a string. however, our docs set this arg with `--set`, which will always interpret strings like "12345678910" as integers. we should use `--set-string` in our documentation so that users who are passing in the arg on the CLI and not in a separate yaml file do not run into validation issues


### References
see [helm docs](https://helm.sh/docs/helm/helm_install/) for details

### Testing

executing `helm template` as described in the existing docs:
```bash
helm template cloudzero-agent ./ --set region=us-east-1 --set apiKey=foobar --set clusterName=foobar --set cloudAccountId=12345678910
Error: values don't meet the specifications of the schema(s) in the following chart(s):
cloudzero-agent:
- cloudAccountId: Invalid type. Expected: string, given: integer
```

using set-string:
```bash
helm template cloudzero-agent ./ --set region=us-east-1 --set apiKey=foobar --set clusterName=foobar --set-string cloudAccountId=12345678910 | grep remote_write -A 1
    remote_write:
      - url: 'https://api.cloudzero.com/v1/container-metrics?cluster_name=foobar&cloud_account_id=12345678910&region=us-east-1'
```

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`