### PR TITLE
[CP-20164] Allow users to set secret filepath and filename for agent server container

### DIFF
--- a/charts/cloudzero-agent/templates/_helpers.tpl
+++ b/charts/cloudzero-agent/templates/_helpers.tpl
@@ -17,19 +17,9 @@ Create chart name and version as used by the chart label.
 {{ .Values.existingSecretName | default (printf "%s-api-key" .Release.Name) }}
 {{- end}}
 
-{{/* Define the name of the file on the container filesystem which holds the CloudZero API key */}}
-{{ define "cloudzero-agent.secretFileName" -}}
-{{ .Values.containerSecretFileNameOverride | default "cz-api-key" }}
-{{- end}}
-
-{{/* Define the path on the container filesystem which holds the CloudZero API key */}}
-{{ define "cloudzero-agent.secretFilePath" -}}
-{{ .Values.existingSecretFilePath | default "/etc/config/prometheus/secrets/" }}
-{{- end}}
-
 {{/* Define the path and filename on the container filesystem which holds the CloudZero API key */}}
 {{ define "cloudzero-agent.secretFileFullPath" -}}
-{{ printf "%s%s" (include "cloudzero-agent.secretFilePath" .) (include "cloudzero-agent.secretFileName" .) }}
+{{ printf "%s%s" .Values.server.containerSecretFilePath .Values.server.containerSecretFileName }}
 {{- end}}
 
 {{ define "cloudzero-agent.configMapName" -}}

--- a/charts/cloudzero-agent/templates/_helpers.tpl
+++ b/charts/cloudzero-agent/templates/_helpers.tpl
@@ -17,6 +17,21 @@ Create chart name and version as used by the chart label.
 {{ .Values.existingSecretName | default (printf "%s-api-key" .Release.Name) }}
 {{- end}}
 
+{{/* Define the name of the file on the container filesystem which holds the CloudZero API key */}}
+{{ define "cloudzero-agent.secretFileName" -}}
+{{ .Values.containerSecretFileNameOverride | default "cz-api-key" }}
+{{- end}}
+
+{{/* Define the path on the container filesystem which holds the CloudZero API key */}}
+{{ define "cloudzero-agent.secretFilePath" -}}
+{{ .Values.existingSecretFilePath | default "/etc/config/prometheus/secrets/" }}
+{{- end}}
+
+{{/* Define the path and filename on the container filesystem which holds the CloudZero API key */}}
+{{ define "cloudzero-agent.secretFileFullPath" -}}
+{{ printf "%s%s" (include "cloudzero-agent.secretFilePath" .) (include "cloudzero-agent.secretFileName" .) }}
+{{- end}}
+
 {{ define "cloudzero-agent.configMapName" -}}
 {{ .Values.prometheusConfig.configMapNameOverride | default (printf "%s-configuration" .Release.Name) }}
 {{- end}}

--- a/charts/cloudzero-agent/templates/cm.yaml
+++ b/charts/cloudzero-agent/templates/cm.yaml
@@ -159,7 +159,7 @@ data:
     remote_write:
       - url: 'https://{{ .Values.host }}/v1/container-metrics?cluster_name={{.Values.clusterName | urlquery}}&cloud_account_id={{.Values.cloudAccountId | urlquery}}&region={{.Values.region | urlquery}}'
         authorization:
-          credentials_file: /etc/config/prometheus/secrets/value
+          credentials_file: {{ include "cloudzero-agent.secretFilePath" . }}{{ include "cloudzero-agent.secretFileName" . }}
         write_relabel_configs:
           - source_labels: [__name__]
             regex: "^({{ include "cloudzero-agent.combineMetrics" . }})$"

--- a/charts/cloudzero-agent/templates/cm.yaml
+++ b/charts/cloudzero-agent/templates/cm.yaml
@@ -159,7 +159,7 @@ data:
     remote_write:
       - url: 'https://{{ .Values.host }}/v1/container-metrics?cluster_name={{.Values.clusterName | urlquery}}&cloud_account_id={{.Values.cloudAccountId | urlquery}}&region={{.Values.region | urlquery}}'
         authorization:
-          credentials_file: {{ include "cloudzero-agent.secretFilePath" . }}{{ include "cloudzero-agent.secretFileName" . }}
+          credentials_file: {{ include "cloudzero-agent.secretFileFullPath" . }}
         write_relabel_configs:
           - source_labels: [__name__]
             regex: "^({{ include "cloudzero-agent.combineMetrics" . }})$"

--- a/charts/cloudzero-agent/templates/deploy.yaml
+++ b/charts/cloudzero-agent/templates/deploy.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
 {{- if .Values.server.deploymentAnnotations }}
   annotations:
-    {{ toYaml .Values.server.deploymentAnnotations | nindent 4 }}
+    {{- toYaml .Values.server.deploymentAnnotations | nindent 4 }}
 {{- end }}
   labels:
     {{- include "cloudzero-agent.server.labels" . | nindent 4 }}

--- a/charts/cloudzero-agent/templates/deploy.yaml
+++ b/charts/cloudzero-agent/templates/deploy.yaml
@@ -39,10 +39,12 @@ spec:
             - -c
             - cp -r /app /checks/bin/ && cloudzero-agent-validator d pre-start -f /checks/config/validator.yml
           volumeMounts:
+          {{- if or .Values.existingSecretName .Values.apiKey }}
             - name: cloudzero-api-key
               mountPath: {{ include "cloudzero-agent.secretFilePath" . }}
               subPath: ""
               readOnly: true
+          {{- end }}
             - name: lifecycle-volume
               mountPath: /checks/bin/
             - name: validator-config-volume

--- a/charts/cloudzero-agent/templates/deploy.yaml
+++ b/charts/cloudzero-agent/templates/deploy.yaml
@@ -40,7 +40,7 @@ spec:
             - cp -r /app /checks/bin/ && cloudzero-agent-validator d pre-start -f /checks/config/validator.yml
           volumeMounts:
             - name: cloudzero-api-key
-              mountPath: /etc/config/prometheus/secrets/
+              mountPath: {{ include "cloudzero-agent.secretFilePath" . }}
               subPath: ""
               readOnly: true
             - name: lifecycle-volume
@@ -96,7 +96,6 @@ spec:
         {{ toYaml .Values.server.args | nindent 12}}
           ports:
             - containerPort: 9090
-
           readinessProbe:
             httpGet:
               path: /-/ready
@@ -127,15 +126,16 @@ spec:
             - name: cloudzero-agent-storage-volume
               mountPath: {{ .Values.server.persistentVolume.mountPath }}
               subPath: "{{ .Values.server.persistentVolume.subPath }}"
-            - name: cloudzero-api-key
-              mountPath: /etc/config/prometheus/secrets/
-              subPath: ""
-              readOnly: true
             - name: lifecycle-volume
               mountPath: /check/
             - name: validator-config-volume
               mountPath: /check/app/config/
-
+          {{- if or .Values.existingSecretName .Values.apiKey }}
+            - name: cloudzero-api-key
+              mountPath: {{ include "cloudzero-agent.secretFilePath" . }}
+              subPath: ""
+              readOnly: true
+          {{- end }}
       securityContext:
         runAsUser: 65534
         runAsNonRoot: true
@@ -172,9 +172,11 @@ spec:
             name: {{ template "cloudzero-agent.validatorConfigMapName" . }}
         - name: lifecycle-volume
           emptyDir: {}
+        {{- if or .Values.existingSecretName .Values.apiKey }}
         - name: cloudzero-api-key
           secret:
             secretName: {{ include "cloudzero-agent.secretName" . }}
+        {{- end }}
         - name: cloudzero-agent-storage-volume
         {{- if .Values.server.persistentVolume.enabled }}
           persistentVolumeClaim:

--- a/charts/cloudzero-agent/templates/deploy.yaml
+++ b/charts/cloudzero-agent/templates/deploy.yaml
@@ -41,7 +41,7 @@ spec:
           volumeMounts:
           {{- if or .Values.existingSecretName .Values.apiKey }}
             - name: cloudzero-api-key
-              mountPath: {{ include "cloudzero-agent.secretFilePath" . }}
+              mountPath: {{ .Values.server.containerSecretFilePath }}
               subPath: ""
               readOnly: true
           {{- end }}
@@ -134,7 +134,7 @@ spec:
               mountPath: /check/app/config/
           {{- if or .Values.existingSecretName .Values.apiKey }}
             - name: cloudzero-api-key
-              mountPath: {{ include "cloudzero-agent.secretFilePath" . }}
+              mountPath: {{ .Values.server.containerSecretFilePath }}
               subPath: ""
               readOnly: true
           {{- end }}

--- a/charts/cloudzero-agent/templates/secret.yaml
+++ b/charts/cloudzero-agent/templates/secret.yaml
@@ -1,5 +1,4 @@
-{{- if or .Values.existingSecretName .Values.existingSecretFilePath }}
-{{- else }}
+{{- if .Values.apiKey }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/cloudzero-agent/templates/secret.yaml
+++ b/charts/cloudzero-agent/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.existingSecretName }}
+{{- if or .Values.existingSecretName .Values.existingSecretFilePath }}
 {{- else }}
 apiVersion: v1
 kind: Secret
@@ -12,7 +12,7 @@ metadata:
   {{- toYaml . | nindent 4 }}
   {{- end }}
 data:
-  value: {{- $apiKey := .Values.apiKey | toString }}
+  {{ include "cloudzero-agent.secretFileName" . }}: {{- $apiKey := .Values.apiKey | toString }}
           {{- if not (regexMatch "^[a-zA-Z0-9-_.~!*'();]+$" $apiKey) }}
           {{- fail "The provided apiKey is invalid. Check that the provided value from apiKey matches exactly what is found in the CloudZero admin page." }}
           {{- end }}

--- a/charts/cloudzero-agent/templates/secret.yaml
+++ b/charts/cloudzero-agent/templates/secret.yaml
@@ -11,7 +11,7 @@ metadata:
   {{- toYaml . | nindent 4 }}
   {{- end }}
 data:
-  {{ include "cloudzero-agent.secretFileName" . }}: {{- $apiKey := .Values.apiKey | toString }}
+  {{ .Values.server.containerSecretFileName }}: {{- $apiKey := .Values.apiKey | toString }}
           {{- if not (regexMatch "^[a-zA-Z0-9-_.~!*'();]+$" $apiKey) }}
           {{- fail "The provided apiKey is invalid. Check that the provided value from apiKey matches exactly what is found in the CloudZero admin page." }}
           {{- end }}

--- a/charts/cloudzero-agent/templates/validatorcm.yaml
+++ b/charts/cloudzero-agent/templates/validatorcm.yaml
@@ -26,7 +26,7 @@ data:
 
     cloudzero:
       host:  https://{{ .Values.host }}
-      credentials_file: /etc/config/prometheus/secrets/value
+      credentials_file: {{ include "cloudzero-agent.secretFilePath" . }}{{ include "cloudzero-agent.secretFileName" . }}
       disable_telemetry: false
 
     prometheus:

--- a/charts/cloudzero-agent/templates/validatorcm.yaml
+++ b/charts/cloudzero-agent/templates/validatorcm.yaml
@@ -26,7 +26,7 @@ data:
 
     cloudzero:
       host:  https://{{ .Values.host }}
-      credentials_file: {{ include "cloudzero-agent.secretFilePath" . }}{{ include "cloudzero-agent.secretFileName" . }}
+      credentials_file: {{ include "cloudzero-agent.secretFileFullPath" . }}
       disable_telemetry: false
 
     prometheus:

--- a/charts/cloudzero-agent/values.schema.json
+++ b/charts/cloudzero-agent/values.schema.json
@@ -22,4 +22,4 @@
     "cloudAccountId",
     "region"
 ]
-  }
+}

--- a/charts/cloudzero-agent/values.yaml
+++ b/charts/cloudzero-agent/values.yaml
@@ -10,10 +10,7 @@ region: null
 apiKey: null
 # -- If set, the agent will use the API key in this Secret to authenticate with CloudZero.
 existingSecretName: null
-# -- If set, the agent will use this file path on the container filesystem to get the CZ API key.
-containerSecretFilePathOverride: null
-# -- If set, the agent will look for a file with this name to get the CZ API key.
-containerSecretFileNameOverride: null
+
 
 # -- The following lists of metrics are required for CloudZero to function.
 # -- Modifications made to these lists may cause issues with the processing of cluster data
@@ -97,6 +94,10 @@ server:
   - --web.console.libraries=/etc/prometheus/console_libraries
   - --web.console.templates=/etc/prometheus/consoles
   - --enable-feature=agent
+  # -- If set, the agent will use this file path on the container filesystem to get the CZ API key.
+  containerSecretFilePath: /etc/config/prometheus/secrets/
+  # -- If set, the agent will look for a file with this name to get the CZ API key.
+  containerSecretFileName: cz-api-key
   persistentVolume:
     existingClaim: ""
     enabled: false

--- a/charts/cloudzero-agent/values.yaml
+++ b/charts/cloudzero-agent/values.yaml
@@ -95,7 +95,7 @@ server:
   # -- The agent will use this file path on the container filesystem to get the CZ API key.
   containerSecretFilePath: /etc/config/prometheus/secrets/
   # -- The agent will look for a file with this name to get the CZ API key.
-  containerSecretFileName: cz-api-key
+  containerSecretFileName: value
   persistentVolume:
     existingClaim: ""
     enabled: false

--- a/charts/cloudzero-agent/values.yaml
+++ b/charts/cloudzero-agent/values.yaml
@@ -10,6 +10,10 @@ region: null
 apiKey: null
 # -- If set, the agent will use the API key in this Secret to authenticate with CloudZero.
 existingSecretName: null
+# -- If set, the agent will use this file path on the container filesystem to get the CZ API key.
+existingSecretFilePath: null
+# -- If set, the agent will look for a file with this name to get the CZ API key.
+containerSecretFileNameOverride: null
 
 # -- The following lists of metrics are required for CloudZero to function.
 # -- Modifications made to these lists may cause issues with the processing of cluster data

--- a/charts/cloudzero-agent/values.yaml
+++ b/charts/cloudzero-agent/values.yaml
@@ -11,7 +11,6 @@ apiKey: null
 # -- If set, the agent will use the API key in this Secret to authenticate with CloudZero.
 existingSecretName: null
 
-
 # -- The following lists of metrics are required for CloudZero to function.
 # -- Modifications made to these lists may cause issues with the processing of cluster data
 kubeMetrics:
@@ -44,7 +43,6 @@ prometheusConfig:
       enabled: true
     # -- Any items added to this list will be added to the Prometheus scrape configuration.
     additionalScrapeJobs: []
-
 
 kube-state-metrics:
   enabled: false
@@ -94,9 +92,9 @@ server:
   - --web.console.libraries=/etc/prometheus/console_libraries
   - --web.console.templates=/etc/prometheus/consoles
   - --enable-feature=agent
-  # -- If set, the agent will use this file path on the container filesystem to get the CZ API key.
+  # -- The agent will use this file path on the container filesystem to get the CZ API key.
   containerSecretFilePath: /etc/config/prometheus/secrets/
-  # -- If set, the agent will look for a file with this name to get the CZ API key.
+  # -- The agent will look for a file with this name to get the CZ API key.
   containerSecretFileName: cz-api-key
   persistentVolume:
     existingClaim: ""

--- a/charts/cloudzero-agent/values.yaml
+++ b/charts/cloudzero-agent/values.yaml
@@ -11,7 +11,7 @@ apiKey: null
 # -- If set, the agent will use the API key in this Secret to authenticate with CloudZero.
 existingSecretName: null
 # -- If set, the agent will use this file path on the container filesystem to get the CZ API key.
-existingSecretFilePath: null
+containerSecretFilePathOverride: null
 # -- If set, the agent will look for a file with this name to get the CZ API key.
 containerSecretFileNameOverride: null
 


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [CloudZero Code of Conduct](https://github.com/cloudzero/template-cloudzero-open-source/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/cloudzero/template-cloudzero-open-source/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

users may want to manage secrets with Hashicrop Vault, which requires no k8s Secrets at all. instead, it injects secrets to the container filesystem based on an annotation. the filename and filepath that the secret is inject to is based on the annotation provided by the user. to allow users to use Vault, we need to allow arbitrary secret filepaths to be specified, and we need to allow users to deploy without any k8s secret at all


### References
Vault documentation: https://developer.hashicorp.com/vault/tutorials/kubernetes/kubernetes-sidecar

### Testing

1. Assert that `apiKey` method continues to work as expected:
```bash
helm upgrade --install cloudzero-agent ./ --set apiKey=$api_key --set clusterName=danm --set region=us-east-1 --set-string cloudAccountId=******** --set kube-state-metrics.enabled=true --set prometheus-node-exporter.enabled=true
```
- confirmed that secret is created, writes are successful

2. Assert that `existingSecretName` method continues to work as expected:
```bash
helm upgrade --install cloudzero-agent ./ --set existingSecretName=cloudzero-agent-key-existing --set clusterName=danm --set region=us-east-1 --set-string cloudAccountId=975482786146 --set host=dev-api.cloudzero.com --set kube-state-metrics.enabled=true --set prometheus-node-exporter.enabled=true
```
- confirmed that secret is NOT created, writes are successful

3. Assert that we can use hashicorp vault to get the api key, and use `containerSecretFilePath` and `containerSecretFileName` to get the vault-injected key.
I'm following [this doc](https://developer.hashicorp.com/vault/tutorials/kubernetes/kubernetes-sidecar#install-the-vault-helm-chart) and adjusting for use with our chart, and omitting some steps for brevity

**install development vault server**
```bash
helm repo add hashicorp https://helm.releases.hashicorp.com
helm repo update
helm install vault hashicorp/vault
```
**set secret in vault**
```bash
kubectl exec -it vault-0 -- /bin/sh
$ vault kv put internal/test/cz-api-key apikey=********
```

**deploy the helm chart**

Given the file test.yaml:
```yaml
server:
  podAnnotations:
    vault.hashicorp.com/agent-inject: 'true'
    vault.hashicorp.com/role: 'cloudzero-agent-with-ui-server'
    vault.hashicorp.com/agent-init-first: 'true'
    vault.hashicorp.com/agent-inject-secret-my-special-key-filename: 'internal/test/cz-api-key'
    vault.hashicorp.com/agent-inject-template-my-special-key-filename: |
      {{- with secret "internal/data/test/cz-api-key" -}}
      {{ .Data.data.apikey }}
      {{- end -}}
```
install with the following command:

```bash
helm upgrade --install cloudzero-agent ./  --set clusterName=danm --set region=us-east-1 --set-string cloudAccountId=12345678910 --set kube-state-metrics.enabled=true --set prometheus-node-exporter.enabled=true  -f test.yaml --set server.containerSecretFilePath=/vault/secrets/ --set server.containerSecretFileName=my-special-key-filename
```
Confirmed that no secret is created, the prometheus agent uses the vault-injected key, and remote writes are successful

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`