### PR TITLE
CP-20388 CP-20359 fix standard labels now showing up

### DIFF
--- a/charts/cloudzero-agent/templates/_helpers.tpl
+++ b/charts/cloudzero-agent/templates/_helpers.tpl
@@ -133,7 +133,7 @@ Combine metric lists
 Required metric labels
 */}}
 {{- define "cloudzero-agent.requiredMetricLabels" -}}
-{{- $requiredSpecialMetricLabels := tuple "_.*" "label_.*" }}
+{{- $requiredSpecialMetricLabels := tuple "_.*" "label_.*" "app.kubernetes.io/*" "k8s.*" -}}
 {{- $requiredCZMetricLabels := tuple "board_asset_tag" "container" "created_by_kind" "created_by_name" "image" "instance" "name" "namespace" "node" "node_kubernetes_io_instance_type" "pod" "product_name" "provider_id" "resource" "unit" "uid" -}}
 {{- $total := concat .Values.additionalMetricLabels $requiredCZMetricLabels $requiredSpecialMetricLabels -}}
 {{- $result := join "|" $total -}}


### PR DESCRIPTION
### Description

Standard labels related to the `kube_pod_lablels` metric are important to correct grouping, and dimension based reporting for kubernetes workloads. 

Previous to this change, this metric was silently not being sent by the agent, preventing such important correlation and cost attribution. 

This change fixes:
- small typo preventing added labels
- addition of standard app.kubernetes.io/* labels and k8s.app* labels. 

### References
* [README exporting-pod-labels section](https://github.com/Cloudzero/cloudzero-charts/tree/develop/charts/cloudzero-agent#exporting-pod-labels)

### Testing
- [x] This change adds test coverage for new/changed/fixed functionality

#### Manual Testing

<details>
   <summary>Condition Reproduction / Testing</summary>
   
   ### Reproduction
   1. Deploy kubernetes cluster
   2. Deploy the chart using the README including kube-state-metrics and node-exporter
   3. On the DB side of Cloudzero - inspect metrics, looking for `kube_pod_labels` metric.

   **RESULT BEFORE**: No data found
   
   **RESULTS AFTER**: Metrics with standard filtration labels found
   
</details>

### Checklist
- [x] I have added documentation for new/changed functionality in this PR
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`