### PR TITLE
CP 20388 improve kubernetes labels documentation

### DIFF
--- a/charts/cloudzero-agent/README.md
+++ b/charts/cloudzero-agent/README.md
@@ -213,18 +213,21 @@ prometheusConfig:
 
 ### Exporting Pod Labels
 
-Pod labels can be exported as metrics using `kube-state-metrics`. Customize the labels to export in `values-override.yaml`:
+Pod labels can be exported as metrics using kube-state-metrics. To customize the labels for export, modify the values-override.yaml file as shown below:
 
-Note a subset of relevant pod labels can be included -- for example only exporting the pod labels named `foo` and `bar` -- can be achieved with the following:
+**Example: Exporting only the pod labels named foo and bar:**
 
 ```yaml
 kube-state-metrics:
   extraArgs:
-    - --metric-labels-allowlist=pods=[foo,bar]
+     - --metric-labels-allowlist=pods=[foo,bar]
 ```
 
 > This is preferable to including all labels with `*` because the performance and memory impact is reduced. Regular expression matching is not currently supported. See the `kube-state-metrics` [documentation](https://github.com/kubernetes/kube-state-metrics/blob/main/docs/developer/cli-arguments.md) for more details.
 
+⚠️ Important: If you are running an existing `kube-state-metrics` instance, ensure that the labels you want to use are whitelisted. kube-state-metrics version 2.x and above will **_not_** export the `kube_pod_labels` metrics unless they are explicitly allowed. This prevents the use of those labels for cost allocation and other purposes. Make sure you have configured the labels at the appropriate level using the --metric-labels-allowlist parameter:
+
+> eg:  `- --metric-labels-allowlist=namespaces=[*],pods=[*],deployments=[app.kubernetes.io/*,k8s.*]`
 
 ## Dependencies
 

--- a/charts/cloudzero-agent/templates/_helpers.tpl
+++ b/charts/cloudzero-agent/templates/_helpers.tpl
@@ -133,7 +133,7 @@ Combine metric lists
 Required metric labels
 */}}
 {{- define "cloudzero-agent.requiredMetricLabels" -}}
-{{- $requiredSpecialMetricLabels := tuple "_.*" "label_.*" }}
+{{- $requiredSpecialMetricLabels := tuple "_.*" "label_.*" "app.kubernetes.io/*" "k8s.*" -}}
 {{- $requiredCZMetricLabels := tuple "board_asset_tag" "container" "created_by_kind" "created_by_name" "image" "instance" "name" "namespace" "node" "node_kubernetes_io_instance_type" "pod" "product_name" "provider_id" "resource" "unit" "uid" -}}
 {{- $total := concat .Values.additionalMetricLabels $requiredCZMetricLabels $requiredSpecialMetricLabels -}}
 {{- $result := join "|" $total -}}

--- a/charts/cloudzero-agent/values.yaml
+++ b/charts/cloudzero-agent/values.yaml
@@ -46,7 +46,8 @@ prometheusConfig:
 
 kube-state-metrics:
   enabled: false
-
+  extraArgs:
+    - --metric-labels-allowlist=namespaces=[*],pods=[*],deployments=[app.kubernetes.io/*,k8s.*]
 prometheus-node-exporter:
   enabled: false
 


### PR DESCRIPTION
This is a follow up to https://github.com/Cloudzero/cloudzero-charts/pull/64

---

### Description

Standard labels related to the `kube_pod_lablels` metric are important to correct grouping, and dimension based reporting for kubernetes workloads. 

Previous to this change, the default kube-state-metrics would not include any label whitelist preventing propagation of `kube_pod_labels`.

This change:
- adds default label whitelist
- updates readme instructions when using existing `kube-state-metrics` service. 


### Testing
- [x] This change adds test coverage for new/changed/fixed functionality

#### Manual Testing

<details>
   <summary>Condition Reproduction / Testing</summary>
   
   ### Reproduction
   1. Deploy kubernetes cluster
   2. Deploy the chart using the README including kube-state-metrics and node-exporter
   3. On the DB side of Cloudzero - inspect metrics, looking for `kube_pod_labels` metric.

   **RESULT BEFORE**: No data found
   
   **RESULTS AFTER**: Metrics with standard filtration labels found
   
</details>

### Checklist
- [x] I have added documentation for new/changed functionality in this PR
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`