### PR TITLE
CP-20643 clean whitespace on cloudAccountId before use

### DIFF
--- a/charts/cloudzero-agent/templates/_helpers.tpl
+++ b/charts/cloudzero-agent/templates/_helpers.tpl
@@ -33,13 +33,12 @@ Create chart name and version as used by the chart label.
 {{/*
   This helper function trims whitespace and newlines from a given string.
 */}}
-{{- define "cleanString" -}}
+{{- define "cloudzero-agent.cleanString" -}}
   {{- $input := . -}}
   {{- $cleaned := trimAll "\n" $input -}}
   {{- $cleaned := trim $cleaned -}}
   {{- $cleaned -}}
 {{- end -}}
-
 
 {{/*
 Create labels for prometheus

--- a/charts/cloudzero-agent/templates/_helpers.tpl
+++ b/charts/cloudzero-agent/templates/_helpers.tpl
@@ -31,6 +31,17 @@ Create chart name and version as used by the chart label.
 {{- end}}
 
 {{/*
+  This helper function trims whitespace and newlines from a given string.
+*/}}
+{{- define "cleanString" -}}
+  {{- $input := . -}}
+  {{- $cleaned := trimAll "\n" $input -}}
+  {{- $cleaned := trim $cleaned -}}
+  {{- $cleaned -}}
+{{- end -}}
+
+
+{{/*
 Create labels for prometheus
 */}}
 {{- define "cloudzero-agent.common.matchLabels" -}}

--- a/charts/cloudzero-agent/templates/cm.yaml
+++ b/charts/cloudzero-agent/templates/cm.yaml
@@ -157,7 +157,7 @@ data:
     {{- end}}
     {{- end}}
     remote_write:
-      - url: 'https://{{ .Values.host }}/v1/container-metrics?cluster_name={{.Values.clusterName | urlquery}}&cloud_account_id={{.Values.cloudAccountId | urlquery}}&region={{.Values.region | urlquery}}'
+      - url: 'https://{{ .Values.host }}/v1/container-metrics?cluster_name={{ .Values.clusterName | urlquery }}&cloud_account_id={{ include "cleanString" .Values.cloudAccountId | urlquery }}&region={{ .Values.region | urlquery }}'
         authorization:
           credentials_file: {{ include "cloudzero-agent.secretFileFullPath" . }}
         write_relabel_configs:

--- a/charts/cloudzero-agent/templates/cm.yaml
+++ b/charts/cloudzero-agent/templates/cm.yaml
@@ -157,7 +157,7 @@ data:
     {{- end}}
     {{- end}}
     remote_write:
-      - url: 'https://{{ .Values.host }}/v1/container-metrics?cluster_name={{ .Values.clusterName | urlquery }}&cloud_account_id={{ include "cleanString" .Values.cloudAccountId | urlquery }}&region={{ .Values.region | urlquery }}'
+      - url: 'https://{{ include "cloudzero-agent.cleanString" .Values.host }}/v1/container-metrics?cluster_name={{ include "cloudzero-agent.cleanString" .Values.clusterName | urlquery }}&cloud_account_id={{ include "cloudzero-agent.cleanString" .Values.cloudAccountId | urlquery }}&region={{ include "cloudzero-agent.cleanString" .Values.region | urlquery }}'
         authorization:
           credentials_file: {{ include "cloudzero-agent.secretFileFullPath" . }}
         write_relabel_configs:

--- a/charts/cloudzero-agent/templates/validatorcm.yaml
+++ b/charts/cloudzero-agent/templates/validatorcm.yaml
@@ -20,7 +20,7 @@ data:
       location: ./cloudzero-agent-validator.log
 
     deployment:
-      account_id: {{ .Values.cloudAccountId }}
+      account_id: "{{ include "cleanString" .Values.cloudAccountId }}"
       cluster_name: {{ .Values.clusterName }}
       region: {{ .Values.region }}
 

--- a/charts/cloudzero-agent/templates/validatorcm.yaml
+++ b/charts/cloudzero-agent/templates/validatorcm.yaml
@@ -20,12 +20,12 @@ data:
       location: ./cloudzero-agent-validator.log
 
     deployment:
-      account_id: "{{ include "cleanString" .Values.cloudAccountId }}"
-      cluster_name: {{ .Values.clusterName }}
-      region: {{ .Values.region }}
+      account_id: "{{ include "cloudzero-agent.cleanString" .Values.cloudAccountId }}"
+      cluster_name: {{ include "cloudzero-agent.cleanString" .Values.clusterName }}
+      region: {{ include "cloudzero-agent.cleanString" .Values.region }}
 
     cloudzero:
-      host:  https://{{ .Values.host }}
+      host:  https://{{ include "cloudzero-agent.cleanString" .Values.host }}
       credentials_file: {{ include "cloudzero-agent.secretFileFullPath" . }}
       disable_telemetry: false
 


### PR DESCRIPTION
### Description

1. Add `cleanString` helper to sanitize strings used as parameters
2. Sanitize the `cloudAccountId`, `host`, `clusterName`, and `region` before use

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

#### Manual Testing

1. Deploy cluster using rancher

2. Apply chart using the following values.yaml overrides:
  ```yaml
  cloudAccountId: |-
    1234567890
  clusterName: local-workshop-cirrus-rancher
  region: us-east-2
  existingSecretName: cz-api-token
  kube-state-metrics:
    enabled: false
  prometheus-node-exporter:
    enabled: false

  validator:
    serviceEndpoints:
      kubeStateMetrics: kube-state-metrics.monitoring.svc.cluster.local:8080
      prometheusNodeExporter: node-exporter-prometheus-node-exporter.monitoring.svc.cluster.local:9100
  ```
    > Notice the intentional newlines added to cloudAccountId parameter above.

3. Apply:
  ```sh
  helm install cloudzero-agent . -f  rancher-agent-values.yaml --namespace $NS
  ```
4. Validate the rendered value in the configMap (scrape config):
  
  ```sh
  kubectl get configmap cloudzero-agent-configuration -n $NS -o yaml
  ```

  **Output:**
  ```yaml
  apiVersion: v1
  data:
    prometheus.yml: |-
      global:
        scrape_interval: 60s
      scrape_configs:
        - job_name: cloudzero-service-endpoints # kube_*, node_* metrics
          honor_labels: true
          honor_timestamps: true
          track_timestamps_staleness: false
          scrape_interval: 1m
          scrape_timeout: 10s
          scrape_protocols:
          - OpenMetricsText1.0.0
          - OpenMetricsText0.0.1
          - PrometheusText0.0.4
          metrics_path: /metrics
          scheme: http
          enable_compression: true
          follow_redirects: true
          enable_http2: true
          relabel_configs:
          - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scrape]
            separator: ;
            regex: "true"
            replacement: $1
            action: keep
          - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scrape_slow]
            separator: ;
            regex: "true"
            replacement: $1
            action: drop
          - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scheme]
            separator: ;
            regex: (https?)
            target_label: __scheme__
            replacement: $1
            action: replace
          - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_path]
            separator: ;
            regex: (.+)
            target_label: __metrics_path__
            replacement: $1
            action: replace
          - source_labels: [__address__, __meta_kubernetes_service_annotation_prometheus_io_port]
            separator: ;
            regex: (.+?)(?::\d+)?;(\d+)
            target_label: __address__
            replacement: $1:$2
            action: replace
          - separator: ;
            regex: __meta_kubernetes_service_annotation_prometheus_io_param_(.+)
            replacement: __param_$1
            action: labelmap
          - separator: ;
            regex: __meta_kubernetes_service_label_(.+)
            replacement: $1
            action: labelmap
          - source_labels: [__meta_kubernetes_namespace]
            separator: ;
            regex: (.*)
            target_label: namespace
            replacement: $1
            action: replace
          - source_labels: [__meta_kubernetes_service_name]
            separator: ;
            regex: (.*)
            target_label: service
            replacement: $1
            action: replace
          - source_labels: [__meta_kubernetes_pod_node_name]
            separator: ;
            regex: (.*)
            target_label: node
            replacement: $1
            action: replace
          metric_relabel_configs:
          - source_labels: [__name__]
            regex: "^(kube_node_info|kube_node_status_capacity|kube_pod_container_resource_limits|kube_pod_container_resource_requests|kube_pod_labels|kube_pod_info|node_dmi_info)$"
            action: keep
          - action: labelkeep
            regex: "^(board_asset_tag|container|created_by_kind|created_by_name|image|instance|name|namespace|node|node_kubernetes_io_instance_type|pod|product_name|provider_id|resource|unit|uid|_.*|label_.*|app.kubernetes.io/*|k8s.*)$"
          kubernetes_sd_configs:
          - role: endpoints
            kubeconfig_file: ""
            follow_redirects: true
            enable_http2: true
        - job_name: cloudzero-nodes-cadvisor # container_* metrics
          honor_timestamps: true
          track_timestamps_staleness: false
          scrape_interval: 1m
          scrape_timeout: 10s
          scrape_protocols:
          - OpenMetricsText1.0.0
          - OpenMetricsText0.0.1
          - PrometheusText0.0.4
          metrics_path: /metrics
          scheme: https
          enable_compression: true
          authorization:
            type: Bearer
            credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
          tls_config:
            ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
            insecure_skip_verify: true
          follow_redirects: true
          enable_http2: true
          relabel_configs:
          - separator: ;
            regex: __meta_kubernetes_node_label_(.+)
            replacement: $1
            action: labelmap
          - separator: ;
            regex: (.*)
            target_label: __address__
            replacement: kubernetes.default.svc:443
            action: replace
          - source_labels: [__meta_kubernetes_node_name]
            separator: ;
            regex: (.+)
            target_label: __metrics_path__
            replacement: /api/v1/nodes/$1/proxy/metrics/cadvisor
            action: replace
          - source_labels: [__meta_kubernetes_node_name]
            target_label: node
            action: replace
          metric_relabel_configs:
          - action: labelkeep
            regex: "^(board_asset_tag|container|created_by_kind|created_by_name|image|instance|name|namespace|node|node_kubernetes_io_instance_type|pod|product_name|provider_id|resource|unit|uid|_.*|label_.*|app.kubernetes.io/*|k8s.*)$"
          - source_labels: [__name__]
            regex: "^(container_cpu_usage_seconds_total|container_memory_working_set_bytes|container_network_receive_bytes_total|container_network_transmit_bytes_total)$"
            action: keep
          kubernetes_sd_configs:
          - role: node
            kubeconfig_file: ""
            follow_redirects: true
            enable_http2: true
      remote_write:
        - url: 'https://api.cloudzero.com/v1/container-metrics?cluster_name=local-workshop-cirrus-rancher&cloud_account_id=1234567890&region=us-east-2'
          authorization:
            credentials_file: /etc/config/prometheus/secrets/value
          write_relabel_configs:
            - source_labels: [__name__]
              regex: "^(kube_node_info|kube_node_status_capacity|kube_pod_container_resource_limits|kube_pod_container_resource_requests|kube_pod_labels|kube_pod_info|node_dmi_info|container_cpu_usage_seconds_total|container_memory_working_set_bytes|container_network_receive_bytes_total|container_network_transmit_bytes_total)$"
              action: keep
          metadata_config:
            send: false
  kind: ConfigMap
  metadata:
    annotations:
      meta.helm.sh/release-name: cloudzero-agent
      meta.helm.sh/release-namespace: cloudzero
    creationTimestamp: "2024-08-02T19:18:42Z"
    labels:
      app.kubernetes.io/component: server
      app.kubernetes.io/instance: cloudzero-agent
      app.kubernetes.io/managed-by: Helm
      app.kubernetes.io/name: cloudzero-agent
      app.kubernetes.io/part-of: cloudzero-agent
      app.kubernetes.io/version: v2.50.1
      helm.sh/chart: cloudzero-agent-0.0.0-dev
    name: cloudzero-agent-configuration
    namespace: cloudzero
    resourceVersion: "451455"
    uid: 1289d4be-99b1-4638-9d1a-77905537cd4d
  ```
  
### Checklist

- [x] I have added documentation for new/changed functionality in this PR
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`