### PR TITLE
CP-20612: do not export all pod and namespace labels by default

### DIFF
--- a/charts/cloudzero-agent/values.yaml
+++ b/charts/cloudzero-agent/values.yaml
@@ -47,7 +47,7 @@ prometheusConfig:
 kube-state-metrics:
   enabled: false
   extraArgs:
-    - --metric-labels-allowlist=pods=[app.kubernetes.io/instance]
+    - --metric-labels-allowlist=pods=[app.kubernetes.io/component]
 prometheus-node-exporter:
   enabled: false
 

--- a/charts/cloudzero-agent/values.yaml
+++ b/charts/cloudzero-agent/values.yaml
@@ -47,7 +47,7 @@ prometheusConfig:
 kube-state-metrics:
   enabled: false
   extraArgs:
-    - --metric-labels-allowlist=pods=[app.kubernetes.io/version,app.kubernetes.io/name,app.kubernetes.io/instance]
+    - --metric-labels-allowlist=pods=[app.kubernetes.io/instance]
 prometheus-node-exporter:
   enabled: false
 

--- a/charts/cloudzero-agent/values.yaml
+++ b/charts/cloudzero-agent/values.yaml
@@ -47,7 +47,7 @@ prometheusConfig:
 kube-state-metrics:
   enabled: false
   extraArgs:
-    - --metric-labels-allowlist=namespaces=[*],pods=[*],deployments=[app.kubernetes.io/*,k8s.*]
+    - --metric-labels-allowlist=pods=[app.kubernetes.io/version,app.kubernetes.io/name,app.kubernetes.io/instance]
 prometheus-node-exporter:
   enabled: false
 


### PR DESCRIPTION
### Description

we'd like to show an example of some reasonable labels to include by default, but we also don't want to include all labels for memory usage reasons.

### Testing
testing in progress - testing by deploying the default and validating data pipeline for default tags.

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`