### PR TITLE
CP-20848 remove quotes from ConfigMap creation

### DIFF
--- a/charts/cloudzero-agent/templates/validatorcm.yaml
+++ b/charts/cloudzero-agent/templates/validatorcm.yaml
@@ -20,7 +20,7 @@ data:
       location: ./cloudzero-agent-validator.log
 
     deployment:
-      account_id: "{{ include "cloudzero-agent.cleanString" .Values.cloudAccountId }}"
+      account_id: {{ include "cloudzero-agent.cleanString" .Values.cloudAccountId }}
       cluster_name: {{ include "cloudzero-agent.cleanString" .Values.clusterName }}
       region: {{ include "cloudzero-agent.cleanString" .Values.region }}
 


### PR DESCRIPTION
### Description

Remove extra quotes from validator configMap template.

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

**TEST**
```sh
$ helm upgrade cloudzero-agent . -f /Users/joe.barnett/company/code/cloudzero-charts-training/guides/02-prom-discovery/cloudzero-agent-values.yaml --namespace $NS
Release "cloudzero-agent" has been upgraded. Happy Helming!
NAME: cloudzero-agent
LAST DEPLOYED: Fri Aug  9 16:56:34 2024
NAMESPACE: cloudzero
STATUS: deployed
REVISION: 2
TEST SUITE: None
```
**get pods**
```sh
$ k -n $NS get pods
NAME                                      READY   STATUS            RESTARTS   AGE
cloudzero-agent-server-5958489bdc-jpmcg   0/2     PodInitializing   0          15s
cloudzero-agent-server-688b446b5b-h7wb5   2/2     Running           0          143m
```

**output**
```json
$ k -n $NS logs -f -c env-validator cloudzero-agent-server-5958489bdc-jpmcg | jq
{
  "account": "975482786146",
  "region": "us-east-2",
  "name": "aws-jb-cirrus-dev-cluster",
  "state": "STATUS_TYPE_INIT_OK",
  "chartVersion": "0.0.0-dev",
  "validatorVersion": "cloudzero-agent-validator.b1a256e.refs/tags/v0.4.0-2024-07-15T15:00:31Z",
  "checks": [
    {
      "name": "egress_reachable",
      "passing": true
    },
    {
      "name": "api_key_valid",
      "passing": true
    }
  ]
}
```
### Checklist

- [x] I have added documentation for new/changed functionality in this PR
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`