### PR TITLE
updated scrape intervals to default to 120s

### DIFF
--- a/charts/cloudzero-agent/templates/cm.yaml
+++ b/charts/cloudzero-agent/templates/cm.yaml
@@ -15,14 +15,14 @@ data:
   {{ .Values.prometheusConfig.configOverride | nindent 4 }}
   {{- else }}
     global:
-      scrape_interval: 60s
+      scrape_interval: {{ .Values.prometheusConfig.globalScrapeInterval }}
     scrape_configs:
       {{- if .Values.prometheusConfig.scrapeJobs.kubeStateMetrics.enabled }}
       - job_name: cloudzero-service-endpoints # kube_*, node_* metrics
         honor_labels: true
         honor_timestamps: true
         track_timestamps_staleness: false
-        scrape_interval: 1m
+        scrape_interval: {{ .Values.prometheusConfig.scrapeJobs.kubeStateMetrics.scrapeInterval }}
         scrape_timeout: 10s
         scrape_protocols:
         - OpenMetricsText1.0.0
@@ -104,7 +104,7 @@ data:
       - job_name: cloudzero-nodes-cadvisor # container_* metrics
         honor_timestamps: true
         track_timestamps_staleness: false
-        scrape_interval: 1m
+        scrape_interval: {{ .Values.prometheusConfig.scrapeJobs.cadvisor.scrapeInterval }}
         scrape_timeout: 10s
         scrape_protocols:
         - OpenMetricsText1.0.0

--- a/charts/cloudzero-agent/values.yaml
+++ b/charts/cloudzero-agent/values.yaml
@@ -34,7 +34,7 @@ prometheusConfig:
   configMapNameOverride: ''
   configMapAnnotations: {}
   configOverride: ''
-  globalScrapeInterval: 120s   
+  globalScrapeInterval: 120s
   scrapeJobs:
     # -- Enables the kube-state-metrics scrape job.
     kubeStateMetrics:

--- a/charts/cloudzero-agent/values.yaml
+++ b/charts/cloudzero-agent/values.yaml
@@ -34,13 +34,16 @@ prometheusConfig:
   configMapNameOverride: ''
   configMapAnnotations: {}
   configOverride: ''
+  globalScrapeInterval: 120s   
   scrapeJobs:
     # -- Enables the kube-state-metrics scrape job.
     kubeStateMetrics:
       enabled: true
+      scrapeInterval: 120s  # Scrape interval for kubeStateMetrics job
     # -- Enables the cadvisor scrape job.
     cadvisor:
       enabled: true
+      scrapeInterval: 120s  # Scrape interval for nodesCadvisor job
     # -- Any items added to this list will be added to the Prometheus scrape configuration.
     additionalScrapeJobs: []
 


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [CloudZero Code of Conduct](https://github.com/cloudzero/template-cloudzero-open-source/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/cloudzero/template-cloudzero-open-source/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description
Updated scrape intervals to default to 120s

Added new values to set the scrap configs if desired as well.

--set prometheusConfig.globalScrapeInterval=30s 
--set prometheusConfig.scrapeJobs.kubeStateMetrics.scrapeInterval=45s 
--set prometheusConfig.scrapeJobs.cadvisor.scrapeInterval=50s 

### References


### Testing

run helm install commands to set various values for the above settings

i.e.
helm upgrade --install cz-agent charts/cloudzero-agent \
  . 
  . 
  .  
  --set prometheusConfig.globalScrapeInterval=30s \
  --set prometheusConfig.scrapeJobs.kubeStateMetrics.scrapeInterval=45s \
  --set prometheusConfig.scrapeJobs.cadvisor.scrapeInterval=50s \

Values will be updated in the agents config map

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`