### PR TITLE
CP-21512 bugfix: remove service discovery reference for static target scrape configuration override example

### DIFF
--- a/charts/cloudzero-agent/README.md
+++ b/charts/cloudzero-agent/README.md
@@ -204,11 +204,6 @@ prometheusConfig:
         target_label: node
         replacement: $1
         action: replace
-      kubernetes_sd_configs:
-        - role: endpoints
-          kubeconfig_file: ""
-          follow_redirects: true
-          enable_http2: true
 ```
 
 ### Exporting Pod Labels


### PR DESCRIPTION
### Description

Fix documented recommended setting when using custom scrape configuration.

### References


### Testing

- [x] Manually tested changes against test cluster.

### Checklist

- [x] I have added documentation for new/changed functionality in this PR
- [ x All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`