### PR TITLE
CP-22180: Bump Upload Artifact Version

### DIFF
--- a/.github/workflows/build-and-publish-chart.yml
+++ b/.github/workflows/build-and-publish-chart.yml
@@ -98,7 +98,7 @@ jobs:
 
       # Step 7: Handle Artifacts and Update Pages
       - name: Upload Chart as Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: agent-chart
           path: .deploy/cloudzero-agent-${{ env.NEW_VERSION }}.tgz
@@ -137,7 +137,7 @@ jobs:
 
       # Step 8: Create GitHub Release
       - name: Create Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v4
         with:
           name: ${{ env.NEW_VERSION }}
           tag_name: ${{ env.NEW_VERSION }}


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [CloudZero Code of Conduct](https://github.com/cloudzero/template-cloudzero-open-source/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/cloudzero/template-cloudzero-open-source/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

This PR bumps the version of `upload-artifact` to prevent the Manual Release Pipeline Step from failing. Currently the project is two versions behind. 

### References

Deprecation Warning for `v2` and `v3`:
https://github.com/actions/upload-artifact


### Checklist

- [n/a] I have added documentation for new/changed functionality in this PR
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`