### PR TITLE
CP-22180 (part 2): Drop Github Release Package Version

### DIFF
--- a/.github/workflows/build-and-publish-chart.yml
+++ b/.github/workflows/build-and-publish-chart.yml
@@ -137,7 +137,7 @@ jobs:
 
       # Step 8: Create GitHub Release
       - name: Create Release
-        uses: softprops/action-gh-release@v4
+        uses: softprops/action-gh-release@v2
         with:
           name: ${{ env.NEW_VERSION }}
           tag_name: ${{ env.NEW_VERSION }}


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [CloudZero Code of Conduct](https://github.com/cloudzero/template-cloudzero-open-source/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/cloudzero/template-cloudzero-open-source/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

This PR is a follow up to https://github.com/Cloudzero/cloudzero-charts/pull/80/files#diff-f7010773715e736f56597bc757055502aeac9d3c3b35f1c3df936862291a34a9R140. We don't need to bump the Github Release package as well.


### References

Original PR: https://github.com/Cloudzero/cloudzero-charts/pull/80/files#diff-f7010773715e736f56597bc757055502aeac9d3c3b35f1c3df936862291a34a9R140

### Checklist

- [x] I have added documentation for new/changed functionality in this PR
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`