### PR TITLE
CP-22609: Add Better Description for Beta Chart Workflow

### DIFF
--- a/.github/workflows/build-and-publish-beta-chart.yml
+++ b/.github/workflows/build-and-publish-beta-chart.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version to use for the release'
+        description: 'Version to use for the release (beta suffix will be automatically appended (e.g. "0.0.1" + "-beta"))'
         required: false
         default: ''
       branch:


### PR DESCRIPTION
This PR modifies the description for the `version` input parameter to the Beta Chart Workflow. Users should be aware that the suffix `-beta` will be appended to the version specified. 

<img width="1258" alt="Screenshot 2024-10-29 at 7 52 28 AM" src="https://github.com/user-attachments/assets/4e1898c7-f1f4-46b0-a3a6-30395ac46f77">
