### PR TITLE
CP-22609: Do not mark Beta Charts as Latest

### DIFF
--- a/.github/workflows/build-and-publish-beta-chart.yml
+++ b/.github/workflows/build-and-publish-beta-chart.yml
@@ -97,7 +97,7 @@ jobs:
           name: ${{ env.NEW_VERSION }}
           tag_name: ${{ env.NEW_VERSION }}
           files: .deploy/cloudzero-agent-${{ env.NEW_VERSION }}.tgz
-          make_latest: true
+          make_latest: false
           target_commitish: ${{ env.COMMIT_HASH }}
           body: |
             ## Installation Instructions


### PR DESCRIPTION
This PR modifies the the Beta Chart Release Workflow so that new `beta` tags are not marked as `latest`. 