### PR TITLE
CP-23051: Change default kube-state-metrics behavior to use Cloudzero subchart

### DIFF
--- a/charts/cloudzero-agent/README.md
+++ b/charts/cloudzero-agent/README.md
@@ -106,40 +106,6 @@ helm install <RELEASE_NAME> cloudzero/cloudzero-agent \
     -f values-override.yaml
 ```
 
-### Metric Exporters
-
-This chart depends on metrics from [kube-state-metrics](https://github.com/kubernetes/kube-state-metrics). There are two installation options for providing the `kube-state-metrics` metrics to the cloudzero-agent. If you don't know which option is right for you, use the first option.
-
-#### Option 1: Use kube-state-metrics subchart (default)
-
-By default, the `kube-state-metrics` subchart comes packaged and deployed with this chart. In this option, no additional configuration is required in the `validator` field.
-The default port for the CloudZero `kube-state-metrics` is `8080`. In the case that you have an existing service using this port, you can set the desired port in the `values-override.yaml` as shown below:
-
-``` yaml
-kube-state-metrics:
-  service:
-    port: 8080
-```
-
-#### Option 2: Use existing kube-state-metrics
-
-Using an existing `kube-state-metrics` exporter may be desirable for minimizing cost. The `cloudzero-agent` will attempt to find an existing `kube-state-metrics` K8s Service by searching for a K8s Service with the annotation `prometheus.io/scrape: "true"`. If an existing `kube-state-metrics` Service exists but does not have that annotation and you do not wish to add it, see the **Custom Scrape Configs** section below.
-
-In addition to the above, the existing `kube-state-metrics` Service address should be added in `values-override.yaml` as shown below so that the `cloudzero-agent` can validate the connection:
-
-```yaml
-validator:
-  serviceEndpoints:
-     kubeStateMetrics: <kube-state-metrics>.<example-namespace>.svc.cluster.local:8080
-```
-
-You will also need to disable the CloudZero KSM:
-
-``` yaml
-kube-state-metrics:
-  enabled: false
-```
-
 ### Secret Management
 
 The chart requires a CloudZero API key to send metric data. Admins can retrieve API keys [here](https://app.cloudzero.com/organization/api-keys).

--- a/charts/cloudzero-agent/README.md
+++ b/charts/cloudzero-agent/README.md
@@ -39,8 +39,6 @@ helm install <RELEASE_NAME> cloudzero/cloudzero-agent \
     --set clusterName=<CLUSTER_NAME> \
     --set-string cloudAccountId=<CLOUD_ACCOUNT_ID> \
     --set region=<REGION> \
-    # optionally deploy kube-state-metrics if it doesn't exist in the cluster already
-    --set kube-state-metrics.enabled=<true|false>
 ```
 
 ### Update Helm Chart
@@ -58,7 +56,6 @@ helm upgrade <RELEASE_NAME> cloudzero/cloudzero-agent \
     --set clusterName=<CLUSTER_NAME> \
     --set-string cloudAccountId=<CLOUD_ACCOUNT_ID> \
     --set region=<REGION> \
-    --set kube-state-metrics.enabled=<true|false>
 ```
 
 ### Mandatory Values
@@ -111,9 +108,15 @@ helm install <RELEASE_NAME> cloudzero/cloudzero-agent \
 
 ### Metric Exporters
 
-This chart depends on metrics from [kube-state-metrics](https://github.com/kubernetes/kube-state-metrics). There are two installation options for providing the `kube-state-metrics` metrics to the cloudzero-agent. If you don't know which option is right for you, use the second option.
+This chart depends on metrics from [kube-state-metrics](https://github.com/kubernetes/kube-state-metrics). There are two installation options for providing the `kube-state-metrics` metrics to the cloudzero-agent. If you don't know which option is right for you, use the first option.
 
-#### Option 1 (default): Use existing kube-state-metrics
+#### Option 1: Use kube-state-metrics subchart (default)
+
+By default, the `kube-state-metrics` subchart comes packaged and deployed with this chart.
+
+In this option, no additional configuration is required in the `validator` field.
+
+#### Option 2: Use existing kube-state-metrics
 
 Using an existing `kube-state-metrics` exporter may be desirable for minimizing cost. By default, the `cloudzero-agent` will attempt to find an existing `kube-state-metrics` K8s Service by searching for a K8s Service with the annotation `prometheus.io/scrape: "true"`. If an existing `kube-state-metrics` Service exists but does not have that annotation and you do not wish to add it, see the **Custom Scrape Configs** section below.
 
@@ -125,16 +128,12 @@ validator:
      kubeStateMetrics: <kube-state-metrics>.<example-namespace>.svc.cluster.local:8080
 ```
 
+You will also need to disable the CloudZero KSM:
 
-#### Option 2: Use kube-state-metrics subchart
-
-Alternatively, deploy the `kube-state-metrics` subchart that comes packaged with this chart. This is done by enabling settings in `values-override.yaml` as shown:
-
-```yaml
+``` yaml
 kube-state-metrics:
-  enabled: true
+    enabled: false
 ```
-In this option, no additional configuration is required in the `validator` field.
 
 ### Secret Management
 

--- a/charts/cloudzero-agent/README.md
+++ b/charts/cloudzero-agent/README.md
@@ -113,12 +113,12 @@ This chart depends on metrics from [kube-state-metrics](https://github.com/kuber
 #### Option 1: Use kube-state-metrics subchart (default)
 
 By default, the `kube-state-metrics` subchart comes packaged and deployed with this chart. In this option, no additional configuration is required in the `validator` field.
-The default port for the CloudZero `kube-state-metrics` is `8081`. In the case that you have an existing service using this port, you can set the desired port in the `values-override.yaml` as shown below:
+The default port for the CloudZero `kube-state-metrics` is `8080`. In the case that you have an existing service using this port, you can set the desired port in the `values-override.yaml` as shown below:
 
 ``` yaml
 kube-state-metrics:
   service:
-    port: 8081
+    port: 8080
 ```
 
 #### Option 2: Use existing kube-state-metrics

--- a/charts/cloudzero-agent/README.md
+++ b/charts/cloudzero-agent/README.md
@@ -132,7 +132,7 @@ You will also need to disable the CloudZero KSM:
 
 ``` yaml
 kube-state-metrics:
-    enabled: false
+  enabled: false
 ```
 
 ### Secret Management

--- a/charts/cloudzero-agent/README.md
+++ b/charts/cloudzero-agent/README.md
@@ -118,7 +118,7 @@ In this option, no additional configuration is required in the `validator` field
 
 #### Option 2: Use existing kube-state-metrics
 
-Using an existing `kube-state-metrics` exporter may be desirable for minimizing cost. By default, the `cloudzero-agent` will attempt to find an existing `kube-state-metrics` K8s Service by searching for a K8s Service with the annotation `prometheus.io/scrape: "true"`. If an existing `kube-state-metrics` Service exists but does not have that annotation and you do not wish to add it, see the **Custom Scrape Configs** section below.
+Using an existing `kube-state-metrics` exporter may be desirable for minimizing cost. The `cloudzero-agent` will attempt to find an existing `kube-state-metrics` K8s Service by searching for a K8s Service with the annotation `prometheus.io/scrape: "true"`. If an existing `kube-state-metrics` Service exists but does not have that annotation and you do not wish to add it, see the **Custom Scrape Configs** section below.
 
 In addition to the above, the existing `kube-state-metrics` Service address should be added in `values-override.yaml` as shown below so that the `cloudzero-agent` can validate the connection:
 

--- a/charts/cloudzero-agent/README.md
+++ b/charts/cloudzero-agent/README.md
@@ -113,7 +113,7 @@ This chart depends on metrics from [kube-state-metrics](https://github.com/kuber
 #### Option 1: Use kube-state-metrics subchart (default)
 
 By default, the `kube-state-metrics` subchart comes packaged and deployed with this chart. In this option, no additional configuration is required in the `validator` field.
-The default port for `kube-state-metrics` is `8080`. In the case that you have an existing service using this port, you can set the desired port in the `values-override.yaml` as shown below:
+The default port for the CloudZero `kube-state-metrics` is `8081`. In the case that you have an existing service using this port, you can set the desired port in the `values-override.yaml` as shown below:
 
 ``` yaml
 kube-state-metrics:

--- a/charts/cloudzero-agent/README.md
+++ b/charts/cloudzero-agent/README.md
@@ -112,9 +112,14 @@ This chart depends on metrics from [kube-state-metrics](https://github.com/kuber
 
 #### Option 1: Use kube-state-metrics subchart (default)
 
-By default, the `kube-state-metrics` subchart comes packaged and deployed with this chart.
+By default, the `kube-state-metrics` subchart comes packaged and deployed with this chart. In this option, no additional configuration is required in the `validator` field.
+The default port for `kube-state-metrics` is `8080`. In the case that you have an existing service using this port, you can set the desired port in the `values-override.yaml` as shown below:
 
-In this option, no additional configuration is required in the `validator` field.
+``` yaml
+kube-state-metrics:
+  service:
+    port: 8081
+```
 
 #### Option 2: Use existing kube-state-metrics
 

--- a/charts/cloudzero-agent/templates/validatorcm.yaml
+++ b/charts/cloudzero-agent/templates/validatorcm.yaml
@@ -33,7 +33,7 @@ data:
       {{- if .Values.validator.serviceEndpoints.kubeStateMetrics }}
       kube_state_metrics_service_endpoint: http://{{ .Values.validator.serviceEndpoints.kubeStateMetrics }}/
       {{- else }}
-      kube_state_metrics_service_endpoint: http://{{- if .Release.Name }}{{.Release.Name}}-{{- end }}kube-state-metrics:8080/
+      kube_state_metrics_service_endpoint: http://{{- if .Release.Name }}{{.Release.Name}}-{{- end }}state-metrics:8080/
       {{- end }}
       {{- if .Values.validator.serviceEndpoints.prometheusNodeExporter }}
       prometheus_node_exporter_service_endpoint: http://{{ .Values.validator.serviceEndpoints.prometheusNodeExporter }}/

--- a/charts/cloudzero-agent/values.yaml
+++ b/charts/cloudzero-agent/values.yaml
@@ -52,6 +52,9 @@ kube-state-metrics:
   fullnameOverride: "cloudzero-state-metrics"
   extraArgs:
     - --metric-labels-allowlist=pods=[app.kubernetes.io/component]
+  podAnnotations:
+    # Ensure the CloudZero KSM pods are not scraped by other scrape jobs
+    prometheus.io/scrape: "false"
 prometheus-node-exporter:
   enabled: false
 

--- a/charts/cloudzero-agent/values.yaml
+++ b/charts/cloudzero-agent/values.yaml
@@ -52,9 +52,9 @@ kube-state-metrics:
   fullnameOverride: "cloudzero-state-metrics"
   extraArgs:
     - --metric-labels-allowlist=pods=[app.kubernetes.io/component]
-  podAnnotations:
-    # Ensure the CloudZero KSM pods are not scraped by other scrape jobs
-    prometheus.io/scrape: "false"
+  # Disable CloudZero KSM as a Scrape Target since the service endpoint is explicity defined
+  # by the Validators config file.
+  prometheusScrape: false
 
 prometheus-node-exporter:
   enabled: false

--- a/charts/cloudzero-agent/values.yaml
+++ b/charts/cloudzero-agent/values.yaml
@@ -49,6 +49,7 @@ prometheusConfig:
 
 kube-state-metrics:
   enabled: false
+  fullnameOverride: "cloudzero-state-metrics"
   extraArgs:
     - --metric-labels-allowlist=pods=[app.kubernetes.io/component]
 prometheus-node-exporter:

--- a/charts/cloudzero-agent/values.yaml
+++ b/charts/cloudzero-agent/values.yaml
@@ -48,7 +48,7 @@ prometheusConfig:
     additionalScrapeJobs: []
 
 kube-state-metrics:
-  enabled: false
+  enabled: true
   fullnameOverride: "cloudzero-state-metrics"
   extraArgs:
     - --metric-labels-allowlist=pods=[app.kubernetes.io/component]

--- a/charts/cloudzero-agent/values.yaml
+++ b/charts/cloudzero-agent/values.yaml
@@ -57,7 +57,7 @@ kube-state-metrics:
   prometheusScrape: false
   # Set a default port other than 8080 to avoid collisions with any existing KSM services.
   service:
-    port: 8081
+    port: 8080
 
 prometheus-node-exporter:
   enabled: false

--- a/charts/cloudzero-agent/values.yaml
+++ b/charts/cloudzero-agent/values.yaml
@@ -55,6 +55,7 @@ kube-state-metrics:
   podAnnotations:
     # Ensure the CloudZero KSM pods are not scraped by other scrape jobs
     prometheus.io/scrape: "false"
+
 prometheus-node-exporter:
   enabled: false
 

--- a/charts/cloudzero-agent/values.yaml
+++ b/charts/cloudzero-agent/values.yaml
@@ -55,6 +55,9 @@ kube-state-metrics:
   # Disable CloudZero KSM as a Scrape Target since the service endpoint is explicity defined
   # by the Validators config file.
   prometheusScrape: false
+  # Set a default port other than 8080 to avoid collisions with any existing KSM services.
+  service:
+    port: 8081
 
 prometheus-node-exporter:
   enabled: false

--- a/docs/releases/0.0.29-beta.md
+++ b/docs/releases/0.0.29-beta.md
@@ -1,0 +1,21 @@
+## [0.0.29-beta](https://github.com/cloudzero/cloudzero-charts/compare/v0.0.28...v0.0.29-beta) (2024-11-12)
+
+Improve Kube State Metrics Install
+
+### Upgrade Steps
+To install, specify the version of the beta chart:
+
+``` bash
+helm upgrade --install -n cz-prom-agent cz-prom-agent charts/cloudzero-agent \
+    --set apiKey=$api_key \
+    --set clusterName='cluster' \
+    --set-string cloudAccountId="account_id" \
+    --set region='region' \
+    --version 0.0.29-beta
+
+```
+
+### Improvements
+* **CloudZero Metrics:** CloudZero State Metrics is enabled/installed by default.
+
+```

--- a/docs/releases/0.0.30-beta.md
+++ b/docs/releases/0.0.30-beta.md
@@ -1,4 +1,4 @@
-## [0.0.29-beta](https://github.com/cloudzero/cloudzero-charts/compare/v0.0.28...v0.0.29-beta) (2024-11-12)
+## [0.0.30-beta](https://github.com/cloudzero/cloudzero-charts/compare/v0.0.28...v0.0.30-beta) (2024-11-12)
 
 Improve Kube State Metrics Install
 
@@ -11,7 +11,7 @@ helm upgrade --install -n cz-prom-agent cz-prom-agent charts/cloudzero-agent \
     --set clusterName='cluster' \
     --set-string cloudAccountId="account_id" \
     --set region='region' \
-    --version 0.0.29-beta
+    --version 0.0.30-beta
 
 ```
 


### PR DESCRIPTION
### Description

This PR does the following:
- enables the CloudZero KSM by default.
- Modifies the KSM annotations so as not to be discoverable by other  scrape jobs.


### Testing

- Test Case 1: Validate that the CloudZero KSM is deployed with the correct name:
 
<img width="752" alt="Screenshot 2024-11-06 at 10 22 00 AM" src="https://github.com/user-attachments/assets/fa42f5b9-9a19-43ca-9969-72a03bb98e69">

- Test Case 2: Validate that other observability services cannot scrape the CloudZero KSM, given the annotation change:
To test this, I installed vanilla Prometheus alongside the Agent in a cluster and checked the Prometheus UI to ensure the Target didn't appear. This was in fact the case.


### Checklist

- [ ] I have added documentation for new/changed functionality in this PR
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`