### PR TITLE
Add tpl helm function on kubeStateMetrics url

### DIFF
--- a/charts/cloudzero-agent/templates/validatorcm.yaml
+++ b/charts/cloudzero-agent/templates/validatorcm.yaml
@@ -31,7 +31,7 @@ data:
 
     prometheus:
       {{- if .Values.validator.serviceEndpoints.kubeStateMetrics }}
-      kube_state_metrics_service_endpoint: http://{{ .Values.validator.serviceEndpoints.kubeStateMetrics }}/
+      kube_state_metrics_service_endpoint: http://{{ tpl .Values.validator.serviceEndpoints.kubeStateMetrics $ }}/
       {{- else }}
       kube_state_metrics_service_endpoint: http://{{- if .Release.Name }}{{.Release.Name}}-{{- end }}kube-state-metrics:8080/
       {{- end }}


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [CloudZero Code of Conduct](https://github.com/cloudzero/template-cloudzero-open-source/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/cloudzero/template-cloudzero-open-source/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

Add `tpl` helm function for kubeStateMetrics url to allow use to provide helm variable instead of static value

### Testing

No tested, can be done by helm values file like 

```
cloudAccountId: "XYZ"
clusterName: "test"
region: "XYZ"
validator:
  serviceEndpoints:
    kubeStateMetrics: "{{ $.Values.clusterName }}.externalMetrics.svc.cluster.local:8080"
```

### Checklist

- [X] I have added documentation for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`