### PR TITLE
CP-23279: separate beta helm repository from stable

### DIFF
--- a/.github/workflows/build-and-publish-beta-chart.yml
+++ b/.github/workflows/build-and-publish-beta-chart.yml
@@ -97,20 +97,19 @@ jobs:
 
       - name: Move release Tarball
         run: |
-          cp .deploy/cloudzero-agent-${{ env.NEW_VERSION }}.tgz ./
+          cp .deploy/cloudzero-agent-${{ env.NEW_VERSION }}.tgz ./beta/
           rm -fr .deploy
 
       - name: Update Index
-        run: helm repo index --url https://cloudzero.github.io/cloudzero-charts .
+        run: helm repo index --url https://cloudzero.github.io/cloudzero-charts/beta ./beta/
 
       - name: Save Index in GH Pages
         run: |
           # copy the new chart and index.yaml
-          git add cloudzero-agent-${{ env.NEW_VERSION }}.tgz index.yaml 
+          git add beta
           git commit -m "Updating ${{ env.NEW_VERSION }} Index"
           git push origin gh-pages
         continue-on-error: true
-
 
       - name: Update Docs for GH Pages
         run: |

--- a/charts/cloudzero-agent/BETA-INSTALLATION.md
+++ b/charts/cloudzero-agent/BETA-INSTALLATION.md
@@ -1,0 +1,22 @@
+# CloudZero Helm Charts Beta Installation Guide
+
+To install a Beta version of the chart, use the `beta` Helm repository. Follow these steps to add the beta repository:
+
+```sh
+helm repo add cloudzero-beta https://cloudzero.github.io/cloudzero-charts/beta
+helm repo update
+```
+
+Here, we name the repository `cloudzero-beta`. Use this name in Helm install commands instead of the standard `cloudzero`. For example:
+
+```sh
+helm install <RELEASE_NAME> cloudzero-beta/cloudzero-agent \
+    --set existingSecretName=<NAME_OF_SECRET> \
+    --set clusterName=<CLUSTER_NAME> \
+    --set-string cloudAccountId=<CLOUD_ACCOUNT_ID> \
+    --set region=<REGION> \
+    # Optionally deploy kube-state-metrics if it doesn't exist in the cluster already
+    --set kube-state-metrics.enabled=<true|false>
+```
+
+Follow all other installation instructions as defined in the [README](./README.md).

--- a/charts/cloudzero-agent/BETA-INSTALLATION.md
+++ b/charts/cloudzero-agent/BETA-INSTALLATION.md
@@ -1,22 +1,119 @@
 # CloudZero Helm Charts Beta Installation Guide
 
-To install a Beta version of the chart, use the `beta` Helm repository. Follow these steps to add the beta repository:
+This guide provides instructions on how to install and work with beta versions of CloudZero Helm charts. Beta versions may include new features and fixes that are not yet available in stable releases. Use them for testing and evaluation purposes.
+
+## Adding the Beta Helm Repository
+
+To access beta versions of the CloudZero Helm charts, you need to add the `beta` Helm repository:
 
 ```sh
 helm repo add cloudzero-beta https://cloudzero.github.io/cloudzero-charts/beta
 helm repo update
 ```
 
-Here, we name the repository `cloudzero-beta`. Use this name in Helm install commands instead of the standard `cloudzero`. For example:
+Here, we name the repository `cloudzero-beta`. Use this name in Helm commands when working with beta charts.
+
+## Searching for Available Beta Versions
+
+By default, Helm does not include pre-release (beta) versions when searching repositories. To list available beta versions of the `cloudzero-agent` chart, use the `--devel` flag:
+
+```sh
+helm search repo cloudzero-beta/cloudzero-agent --devel
+```
+
+**Example Output:**
+
+```
+NAME                            CHART VERSION   APP VERSION     DESCRIPTION                                       
+cloudzero-beta/cloudzero-agent  0.0.29-beta     v2.50.1         A chart for using Prometheus in agent mode to s...
+```
+
+The `--devel` flag includes development versions (alpha, beta, and release candidate) in the search results.
+
+## Installing a Beta Version
+
+There are two ways to install a beta version of the chart:
+
+### Method 1: Using the `--devel` Flag
+
+This method installs the latest beta version available.
 
 ```sh
 helm install <RELEASE_NAME> cloudzero-beta/cloudzero-agent \
+    --devel \
     --set existingSecretName=<NAME_OF_SECRET> \
     --set clusterName=<CLUSTER_NAME> \
     --set-string cloudAccountId=<CLOUD_ACCOUNT_ID> \
     --set region=<REGION> \
-    # Optionally deploy kube-state-metrics if it doesn't exist in the cluster already
-    --set kube-state-metrics.enabled=<true|false>
+    --set kube-state-metrics.enabled=<true|false> \
+    --create-namespace
 ```
 
-Follow all other installation instructions as defined in the [README](./README.md).
+- The `--devel` flag allows Helm to consider beta versions when resolving the chart version.
+- Replace `<RELEASE_NAME>` with the desired name for your Helm release.
+
+### Method 2: Specifying the Exact Beta Version
+
+If you want to install a specific beta version, specify it using the `--version` flag:
+
+```sh
+helm install <RELEASE_NAME> cloudzero-beta/cloudzero-agent \
+    --version <CHART_VERSION> \
+    --set existingSecretName=<NAME_OF_SECRET> \
+    --set clusterName=<CLUSTER_NAME> \
+    --set-string cloudAccountId=<CLOUD_ACCOUNT_ID> \
+    --set region=<REGION> \
+    --set kube-state-metrics.enabled=<true|false> \
+    --create-namespace
+```
+
+- Replace `<CHART_VERSION>` with the specific beta version (e.g., `0.0.29-beta`).
+- This method does not require the `--devel` flag since you are explicitly specifying the version.
+
+## Listing All Available Versions
+
+To see all available versions of the `cloudzero-agent` chart, including both stable and beta versions, use the following command:
+
+```sh
+helm search repo cloudzero-beta/cloudzero-agent --versions --devel
+```
+
+**Example Output:**
+
+```
+NAME                            CHART VERSION   APP VERSION     DESCRIPTION                                       
+cloudzero-beta/cloudzero-agent  0.0.29-beta     v2.50.1         Cloudzero Agent with feature to s...
+cloudzero-beta/cloudzero-agent  0.0.28-beta     v2.50.0         Cloudzero Agent with feature to u...
+```
+
+- The `--versions` flag lists all versions of the chart.
+- The `--devel` flag includes pre-release versions in the list.
+
+## Updating the Beta Chart Repository
+
+Ensure that you have the latest versions of the beta charts by updating the repository:
+
+```sh
+helm repo update
+```
+
+## Additional Installation Instructions
+
+Follow all other installation instructions as defined in the [README](./README.md), replacing `cloudzero` with `cloudzero-beta` in repository references when working with beta charts.
+
+## Notes and Best Practices
+
+- **Use in Testing Environments:** Beta versions are for testing and evaluation. Use them in non-production environments.
+- **Specify Versions for Consistency:** When deploying to multiple environments, specify the exact chart version to ensure consistency.
+- **Stay Informed of Changes:** Beta versions may introduce changes. Review release notes or change logs associated with the beta version you plan to use.
+- **Remove Beta Repository When Not in Use:** If you no longer need access to beta charts, remove the repository to prevent accidental installation:
+
+  ```sh
+  helm repo remove cloudzero-beta
+  ```
+
+## Troubleshooting
+
+- **Chart Not Found Error:** If you encounter an error like `no chart version found for cloudzero-agent-`, ensure you are using the `--devel` flag or specifying the exact beta version with `--version`.
+- **Repository Not Updated:** If Helm doesn't recognize the latest beta charts, run `helm repo update` to refresh the repository cache.
+- **Pre-release Versions Ignored:** Remember that Helm ignores pre-release versions by default. Always use `--devel` when searching or installing beta charts unless specifying the version.


### PR DESCRIPTION
### Description

- CP-23279: publish to beta directory to prevent harm for stable versions
- CP-23279 update beta installation instructions

### Testing

TBD 

### Checklist

- [x] I have added documentation for new/changed functionality in this PR
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`