### PR TITLE
CP-23388: Define Static KubeStateMetrics Target Endpoint

### DIFF
--- a/charts/cloudzero-agent/BETA-INSTALLATION.md
+++ b/charts/cloudzero-agent/BETA-INSTALLATION.md
@@ -45,7 +45,7 @@ helm install <RELEASE_NAME> cloudzero-beta/cloudzero-agent \
     --set clusterName=<CLUSTER_NAME> \
     --set-string cloudAccountId=<CLOUD_ACCOUNT_ID> \
     --set region=<REGION> \
-    --set kube-state-metrics.enabled=<true|false> \
+    --set kube_state_metrics.enabled=<true|false> \
     --create-namespace
 ```
 
@@ -63,7 +63,7 @@ helm install <RELEASE_NAME> cloudzero-beta/cloudzero-agent \
     --set clusterName=<CLUSTER_NAME> \
     --set-string cloudAccountId=<CLOUD_ACCOUNT_ID> \
     --set region=<REGION> \
-    --set kube-state-metrics.enabled=<true|false> \
+    --set kube_state_metrics.enabled=<true|false> \
     --create-namespace
 ```
 

--- a/charts/cloudzero-agent/Chart.lock
+++ b/charts/cloudzero-agent/Chart.lock
@@ -5,5 +5,5 @@ dependencies:
 - name: prometheus-node-exporter
   repository: https://prometheus-community.github.io/helm-charts
   version: 4.24.0
-digest: sha256:827a33fa07fde17be0bf808e0beba3ca7b23c9fc1960580b2ba6d0ecc0b57a3f
-generated: "2024-03-20T11:42:44.034766-04:00"
+digest: sha256:254bcb4b6b7f42a53ad1ec5885e079958efa2a09f30ffafe03c6ad0eccd06f7d
+generated: "2024-11-14T04:46:38.987981-08:00"

--- a/charts/cloudzero-agent/Chart.yaml
+++ b/charts/cloudzero-agent/Chart.yaml
@@ -11,7 +11,7 @@ dependencies:
   - name: kube-state-metrics
     version: "5.15.*"
     repository: https://prometheus-community.github.io/helm-charts
-    condition: kube_state_metrics.enabled
+    condition: kubeStateMetrics.enabled
   - name: prometheus-node-exporter
     version: "4.24.*"
     repository: https://prometheus-community.github.io/helm-charts

--- a/charts/cloudzero-agent/Chart.yaml
+++ b/charts/cloudzero-agent/Chart.yaml
@@ -8,7 +8,7 @@ maintainers:
     email: support@cloudzero.com
 appVersion: "v2.50.1"
 dependencies:
-  - name: kube_state_metrics
+  - name: kube-state-metrics
     version: "5.15.*"
     repository: https://prometheus-community.github.io/helm-charts
     condition: kube_state_metrics.enabled

--- a/charts/cloudzero-agent/Chart.yaml
+++ b/charts/cloudzero-agent/Chart.yaml
@@ -8,10 +8,10 @@ maintainers:
     email: support@cloudzero.com
 appVersion: "v2.50.1"
 dependencies:
-  - name: kube-state-metrics
+  - name: kube_state_metrics
     version: "5.15.*"
     repository: https://prometheus-community.github.io/helm-charts
-    condition: kube-state-metrics.enabled
+    condition: kube_state_metrics.enabled
   - name: prometheus-node-exporter
     version: "4.24.*"
     repository: https://prometheus-community.github.io/helm-charts

--- a/charts/cloudzero-agent/README.md
+++ b/charts/cloudzero-agent/README.md
@@ -144,50 +144,6 @@ kube-state-metrics:
     repository: my-custom-kube-state-metrics/kube-state-metrics
 ```
 
-### Custom Scrape Configs
-
-If running without the default `kube-state-metrics` exporter subchart and your existing `kube-state-metrics` deployment does not have the required `prometheus.io/scrape: "true"`, adjust the Prometheus scrape configs as shown:
-
-`values-override.yaml`
-```yaml
-prometheusConfig:
-  scrapeJobs:
-    kubeStateMetrics:
-      enabled: false # this disables the default kube-state-metrics scrape job, which will be replaced by an entry in additionalScrapeJobs
-    additionalScrapeJobs:
-    - job_name: custom-kube-state-metrics
-      honor_timestamps: true
-      scrape_interval: 1m
-      scrape_timeout: 10s
-      metrics_path: /metrics
-      static_configs:
-        - targets:
-          - 'my-kube-state-metrics-service.default.svc.cluster.local:8080'
-      relabel_configs:
-      - separator: ;
-        regex: __meta_kubernetes_service_label_(.+)
-        replacement: $1
-        action: labelmap
-      - source_labels: [__meta_kubernetes_namespace]
-        separator: ;
-        regex: (.*)
-        target_label: namespace
-        replacement: $1
-        action: replace
-      - source_labels: [__meta_kubernetes_service_name]
-        separator: ;
-        regex: (.*)
-        target_label: service
-        replacement: $1
-        action: replace
-      - source_labels: [__meta_kubernetes_pod_node_name]
-        separator: ;
-        regex: (.*)
-        target_label: node
-        replacement: $1
-        action: replace
-```
-
 ### Exporting Pod Labels
 
 Pod labels can be exported as metrics using kube-state-metrics. To customize the labels for export, modify the values-override.yaml file as shown below:

--- a/charts/cloudzero-agent/templates/cm.yaml
+++ b/charts/cloudzero-agent/templates/cm.yaml
@@ -33,6 +33,9 @@ data:
         enable_compression: true
         follow_redirects: true
         enable_http2: true
+        static_configs:
+          - targets:
+            - {{ printf "%s.%s.svc.cluster.local:%d" .Values.kube_state_metrics.fullnameOverride .Release.Namespace .Values.kube_state_metrics.service.port }}
         relabel_configs:
         - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scrape]
           separator: ;
@@ -94,11 +97,6 @@ data:
           action: keep
         - action: labelkeep
           regex: "^({{ include "cloudzero-agent.requiredMetricLabels" . }})$"
-        kubernetes_sd_configs:
-        - role: endpoints
-          kubeconfig_file: ""
-          follow_redirects: true
-          enable_http2: true
       {{- end }}
       {{- if .Values.prometheusConfig.scrapeJobs.cadvisor.enabled }}
       - job_name: cloudzero-nodes-cadvisor # container_* metrics

--- a/charts/cloudzero-agent/templates/cm.yaml
+++ b/charts/cloudzero-agent/templates/cm.yaml
@@ -35,7 +35,7 @@ data:
         enable_http2: true
         static_configs:
           - targets:
-            - {{ printf "%s.%s.svc.cluster.local:%d" .Values.kube_state_metrics.fullnameOverride .Release.Namespace .Values.kube_state_metrics.service.port }}
+            - {{ printf "%s.%s.svc.cluster.local:%d" .Values.kube_state_metrics.fullnameOverride .Release.Namespace (int .Values.kube_state_metrics.service.port) }}
         relabel_configs:
         - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scrape]
           separator: ;

--- a/charts/cloudzero-agent/templates/cm.yaml
+++ b/charts/cloudzero-agent/templates/cm.yaml
@@ -65,7 +65,7 @@ data:
           action: labelkeep
         static_configs:
         - targets:
-            - {{ printf "%s-kube-state-metrics.%s.svc.cluster.local:%d" .Release.Name .Release.Namespace (int .Values.kube_state_metrics.service.port) }}
+            - {{ printf "%s-kube-state-metrics.%s.svc.cluster.local:%d" .Release.Name .Release.Namespace (int .Values.kubeStateMetrics.service.port) }}
       {{- end }}
       {{- if .Values.prometheusConfig.scrapeJobs.cadvisor.enabled }}
       - job_name: cloudzero-nodes-cadvisor # container_* metrics

--- a/charts/cloudzero-agent/templates/cm.yaml
+++ b/charts/cloudzero-agent/templates/cm.yaml
@@ -57,9 +57,7 @@ data:
           action: replace
         metric_relabel_configs:
         - source_labels: [__name__]
-          separator: ;
-          regex: ^(kube_node_info|kube_node_status_capacity|kube_pod_container_resource_limits|kube_pod_container_resource_requests|kube_pod_labels|kube_pod_info)$
-          replacement: $1
+          regex: "^({{ join "|" .Values.kubeMetrics }})$"
           action: keep
         - separator: ;
           regex: ^(board_asset_tag|container|created_by_kind|created_by_name|image|instance|name|namespace|node|node_kubernetes_io_instance_type|pod|product_name|provider_id|resource|unit|uid|_.*|label_.*|app.kubernetes.io/*|k8s.*)$

--- a/charts/cloudzero-agent/templates/cm.yaml
+++ b/charts/cloudzero-agent/templates/cm.yaml
@@ -18,11 +18,10 @@ data:
       scrape_interval: {{ .Values.prometheusConfig.globalScrapeInterval }}
     scrape_configs:
       {{- if .Values.prometheusConfig.scrapeJobs.kubeStateMetrics.enabled }}
-      - job_name: cloudzero-service-endpoints # kube_*, node_* metrics
-        honor_labels: true
+      - job_name: static-kube-state-metrics
         honor_timestamps: true
         track_timestamps_staleness: false
-        scrape_interval: {{ .Values.prometheusConfig.scrapeJobs.kubeStateMetrics.scrapeInterval }}
+        scrape_interval: 1m
         scrape_timeout: 10s
         scrape_protocols:
         - OpenMetricsText1.0.0
@@ -33,42 +32,7 @@ data:
         enable_compression: true
         follow_redirects: true
         enable_http2: true
-        static_configs:
-          - targets:
-            - {{ printf "%s-kube-state-metrics.%s.svc.cluster.local:%d" .Release.Name .Release.Namespace (int .Values.kube_state_metrics.service.port) }}
         relabel_configs:
-        - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scrape]
-          separator: ;
-          regex: "true"
-          replacement: $1
-          action: keep
-        - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scrape_slow]
-          separator: ;
-          regex: "true"
-          replacement: $1
-          action: drop
-        - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scheme]
-          separator: ;
-          regex: (https?)
-          target_label: __scheme__
-          replacement: $1
-          action: replace
-        - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_path]
-          separator: ;
-          regex: (.+)
-          target_label: __metrics_path__
-          replacement: $1
-          action: replace
-        - source_labels: [__address__, __meta_kubernetes_service_annotation_prometheus_io_port]
-          separator: ;
-          regex: (.+?)(?::\d+)?;(\d+)
-          target_label: __address__
-          replacement: $1:$2
-          action: replace
-        - separator: ;
-          regex: __meta_kubernetes_service_annotation_prometheus_io_param_(.+)
-          replacement: __param_$1
-          action: labelmap
         - separator: ;
           regex: __meta_kubernetes_service_label_(.+)
           replacement: $1
@@ -93,10 +57,17 @@ data:
           action: replace
         metric_relabel_configs:
         - source_labels: [__name__]
-          regex: "^({{ join "|" .Values.kubeMetrics }})$"
+          separator: ;
+          regex: ^(kube_node_info|kube_node_status_capacity|kube_pod_container_resource_limits|kube_pod_container_resource_requests|kube_pod_labels|kube_pod_info)$
+          replacement: $1
           action: keep
-        - action: labelkeep
-          regex: "^({{ include "cloudzero-agent.requiredMetricLabels" . }})$"
+        - separator: ;
+          regex: ^(board_asset_tag|container|created_by_kind|created_by_name|image|instance|name|namespace|node|node_kubernetes_io_instance_type|pod|product_name|provider_id|resource|unit|uid|_.*|label_.*|app.kubernetes.io/*|k8s.*)$
+          replacement: $1
+          action: labelkeep
+        static_configs:
+        - targets:
+            - {{ printf "%s-kube-state-metrics.%s.svc.cluster.local:%d" .Release.Name .Release.Namespace (int .Values.kube_state_metrics.service.port) }}
       {{- end }}
       {{- if .Values.prometheusConfig.scrapeJobs.cadvisor.enabled }}
       - job_name: cloudzero-nodes-cadvisor # container_* metrics

--- a/charts/cloudzero-agent/templates/cm.yaml
+++ b/charts/cloudzero-agent/templates/cm.yaml
@@ -35,7 +35,7 @@ data:
         enable_http2: true
         static_configs:
           - targets:
-            - {{ printf "%s.%s.svc.cluster.local:%d" .Values.kube_state_metrics.fullnameOverride .Release.Namespace (int .Values.kube_state_metrics.service.port) }}
+            - {{ printf "%s-kube-state-metrics.%s.svc.cluster.local:%d" .Release.Name .Release.Namespace (int .Values.kube_state_metrics.service.port) }}
         relabel_configs:
         - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scrape]
           separator: ;

--- a/charts/cloudzero-agent/values.yaml
+++ b/charts/cloudzero-agent/values.yaml
@@ -47,7 +47,7 @@ prometheusConfig:
     # -- Any items added to this list will be added to the Prometheus scrape configuration.
     additionalScrapeJobs: []
 
-kube_state_metrics:
+kubeStateMetrics:
   enabled: true
   fullnameOverride: "cloudzero-state-metrics"
   extraArgs:

--- a/charts/cloudzero-agent/values.yaml
+++ b/charts/cloudzero-agent/values.yaml
@@ -47,7 +47,7 @@ prometheusConfig:
     # -- Any items added to this list will be added to the Prometheus scrape configuration.
     additionalScrapeJobs: []
 
-kube-state-metrics:
+kube_state_metrics:
   enabled: true
   fullnameOverride: "cloudzero-state-metrics"
   extraArgs:


### PR DESCRIPTION
This PR defines a static target for the CloudZero KSM. Typically this value is dynamically discovered by Prometheus, but given the CloudZero KSM disables discovery, we must explicitly define it. The `configmap` resolves to:
```
scrape_configs:
      - job_name: cloudzero-service-endpoints # kube_*, node_* metrics
      ...
        static_configs:
          - targets:
            - cz-prom-agent-kube-state-metrics.prom-agent.svc.cluster.local:8080   <-- Endpoint


```

We can validate that this is in fact the endpoint by running:
``` bash
 kubectl run -i --tty --rm debug --image=busybox --restart=Never -- nslookup cz-prom-agent-kube-state-metrics.prom-agent.svc.cluster.local  
```
### Checklist

- [x] I have added documentation for new/changed functionality in this PR
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`