### PR TITLE
[CP-22730] update doc location for doc check in beta release process

### DIFF
--- a/.github/workflows/build-and-publish-beta-chart.yml
+++ b/.github/workflows/build-and-publish-beta-chart.yml
@@ -79,7 +79,7 @@ jobs:
 
       - name: Validate Release Notes are Present
         run: |
-          if [ ! -f "docs/releases/${{ env.NEW_VERSION }}.md" ]; then
+          if [ ! -f "charts/cloudzero-agent/docs/releases/${{ env.NEW_VERSION }}.md" ]; then
             echo "Release notes for ${{ env.NEW_VERSION }} are missing. Please create a release notes file at docs/releases/${{ env.NEW_VERSION }}.md"
             exit 1
           fi


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [CloudZero Code of Conduct](https://github.com/cloudzero/template-cloudzero-open-source/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/cloudzero/template-cloudzero-open-source/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description
release docs are kept in charts/cloudzero-agent/docs/releases, but the beta release doc check checks at the top level.


- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`