### PR TITLE
CP-23426: use insights-controller service account for init job

### DIFF
--- a/charts/cloudzero-insights-controller/templates/init-job.yaml
+++ b/charts/cloudzero-insights-controller/templates/init-job.yaml
@@ -13,6 +13,7 @@ spec:
       labels:
         {{- include "insights-controller.labels" . | nindent 8 }}
     spec:
+      serviceAccountName: {{ include "insights-controller.serviceAccountName" . }}
       restartPolicy: Never
       containers:
         - name: start-scrape


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [CloudZero Code of Conduct](https://github.com/cloudzero/template-cloudzero-open-source/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/cloudzero/template-cloudzero-open-source/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description
some security policies do not allow using the default service account - this updates the init job to use the chart service account

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`