### PR TITLE
CP-23465: increase default replica count for insights controller

### DIFF
--- a/charts/cloudzero-insights-controller/values.yaml
+++ b/charts/cloudzero-insights-controller/values.yaml
@@ -11,8 +11,6 @@ apiKey: null
 # -- If set, the agent will use the API key in this Secret to authenticate with CloudZero.
 existingSecretName: null
 
-replicaCount: 3
-
 nameOverride: ""
 fullnameOverride: ""
 
@@ -26,6 +24,7 @@ annotations:
     - '.*'
 
 server:
+  replicaCount: 3
   service:
     port: 443
   image:


### PR DESCRIPTION
### Description
For HA for the insights-controller, increasing the replicacount should help us be resilient to pod restarts. we should probably add some pod anti affinities to keep pods from scheduling on the same node, and maybe even try to get them scheduling on nodes in different AZs, but I think this will do for now


### Checklist

- [ ] I have added documentation for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`