### PR TITLE
[CP-22730] fix doc path on chart release

### DIFF
--- a/.github/workflows/build-and-publish-beta-chart.yml
+++ b/.github/workflows/build-and-publish-beta-chart.yml
@@ -156,4 +156,4 @@ jobs:
           files: .deploy/cloudzero-agent-${{ env.NEW_VERSION }}.tgz
           make_latest: false
           target_commitish: ${{ env.COMMIT_HASH }}
-          body_path: ${{ github.workspace }}/docs/releases/${{ env.NEW_VERSION }}.md
+          body_path: ${{ github.workspace }}/charts/cloudzero-agent/docs/releases/${{ env.NEW_VERSION }}.md


### PR DESCRIPTION

### Description

one more fix for doc path

### References
fixes: https://github.com/Cloudzero/cloudzero-charts/actions/runs/11944320449/job/33295067334

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`