### PR TITLE
CP-23303: remove Node Exporter references

### DIFF
--- a/.github/workflows/test-chart.yml
+++ b/.github/workflows/test-chart.yml
@@ -45,7 +45,6 @@ jobs:
           helm dependency update
           ct lint --debug --charts . \
             --chart-repos=kube-state-metrics=$PROM_CHART_REPO \
-            --chart-repos=prometheus-node-exporter=$PROM_CHART_REPO \
             --helm-lint-extra-args "--set=existingSecretName=api-token,clusterName=$CLUSTER_NAME,cloudAccountId=$CLOUD_ACCOUNT_ID,region=$REGION"
 
   # This job tests the chart on a KinD cluster
@@ -119,12 +118,10 @@ jobs:
           helm dependency update
           ct install --charts . \
             --chart-repos=kube-state-metrics=$PROM_CHART_REPO \
-            --chart-repos=prometheus-node-exporter=$PROM_CHART_REPO \
             --namespace $NAMESPACE \
             --helm-extra-set-args "\
               --set=existingSecretName=api-token \
               --set=clusterName=$CLUSTER_NAME \
               --set=cloudAccountId=$CLOUD_ACCOUNT_ID \
               --set=region=$REGION \
-              --set=kube-state-metrics.enabled=true \
-              --set=prometheus-node-exporter.enabled=true"
+              --set=kube-state-metrics.enabled=true"

--- a/charts/cloudzero-agent/Chart.lock
+++ b/charts/cloudzero-agent/Chart.lock
@@ -2,8 +2,5 @@ dependencies:
 - name: kube-state-metrics
   repository: https://prometheus-community.github.io/helm-charts
   version: 5.15.3
-- name: prometheus-node-exporter
-  repository: https://prometheus-community.github.io/helm-charts
-  version: 4.24.0
-digest: sha256:827a33fa07fde17be0bf808e0beba3ca7b23c9fc1960580b2ba6d0ecc0b57a3f
-generated: "2024-03-20T11:42:44.034766-04:00"
+digest: sha256:46007169320c037bcfd18a07acf3ad859c455ef2d01f5bf281bfeadbdf4502e6
+generated: "2024-11-19T14:07:51.973517-05:00"

--- a/charts/cloudzero-agent/Chart.yaml
+++ b/charts/cloudzero-agent/Chart.yaml
@@ -12,7 +12,3 @@ dependencies:
     version: "5.15.*"
     repository: https://prometheus-community.github.io/helm-charts
     condition: kube-state-metrics.enabled
-  - name: prometheus-node-exporter
-    version: "4.24.*"
-    repository: https://prometheus-community.github.io/helm-charts
-    condition: prometheus-node-exporter.enabled

--- a/charts/cloudzero-agent/docs/deploy-validation.md
+++ b/charts/cloudzero-agent/docs/deploy-validation.md
@@ -32,7 +32,7 @@ kubectl -n cloudzero-agent logs -f -c env-validator <pod_name>
 Diagnostics are run at 3 lifecycle phases of the `cloudzero-agent` pod deployment:
 
 1. `Pod initialization` - basic configuration elements are validated, such as the API key and egress reachability.
-2. `Post pod start` - the prometheus container runs the `post-start` checks, then posts a `cluster up` status to the Cloudzero API. Checks include validating the API key, capturing the Kubernetes version, inspecting the scrape configuration, checking the kube-state-metrics service, and the prometheus-node-exporter server reachability. The results are logged to the `/prometheus/cloudzero-validator.log` file in the container.
+2. `Post pod start` - the prometheus container runs the `post-start` checks, then posts a `cluster up` status to the Cloudzero API. Checks include validating the API key, capturing the Kubernetes version, inspecting the scrape configuration, and checking the kube-state-metrics service. The results are logged to the `/prometheus/cloudzero-validator.log` file in the container.
 3. `Pre pod stop` - the prometheus container runs the `pre-stop` checks (usually none), then posts a `cluster down` status to the Cloudzero API.
 
 Based on the above statements, it is also possible to diagnose from the perspective of the prometheus container. To inspect the logs, use the following command, replacing the pod name with that of your current deployment:
@@ -54,9 +54,8 @@ In the screenshot above, notice the `checks` section. This section allows you to
 The CloudZero Agent has the following requirements:
 
 1. It must be able to communicate with the `Kubernetes metrics server`.
-2. It must be able to communicate with the `Prometheus node exporter`.
-3. It must be provided with a valid Cloudzero API Token.
-4. It must be able to communicate with the Cloudzero API to send metrics.
-5. It must be configured to collect the correct metrics and labels to the Cloudzero API.
+2. It must be provided with a valid Cloudzero API Token.
+3. It must be able to communicate with the Cloudzero API to send metrics.
+4. It must be configured to collect the correct metrics and labels to the Cloudzero API.
 
 Based on these 5 requirements, the checks have been designed to help identify problems quickly during a new deployment. Using the tool, and log output, it should be possible to confirm this information. If all else fails, reach out to support@cloudzero.com and provide the output, along with the output of `kubectl -n <namespace> describe all` for the deployment.

--- a/charts/cloudzero-agent/templates/validatorcm.yaml
+++ b/charts/cloudzero-agent/templates/validatorcm.yaml
@@ -35,11 +35,6 @@ data:
       {{- else }}
       kube_state_metrics_service_endpoint: http://{{- if .Release.Name }}{{.Release.Name}}-{{- end }}kube-state-metrics:8080/
       {{- end }}
-      {{- if .Values.validator.serviceEndpoints.prometheusNodeExporter }}
-      prometheus_node_exporter_service_endpoint: http://{{ .Values.validator.serviceEndpoints.prometheusNodeExporter }}/
-      {{- else }}
-      prometheus_node_exporter_service_endpoint: http://{{- if .Release.Name }}{{.Release.Name}}-{{- end }}prometheus-node-exporter:9100/
-      {{- end }}
       executable: /bin/prometheus
       configurations:
         - /etc/prometheus/prometheus.yml
@@ -57,7 +52,6 @@ data:
           checks:
             - k8s_version
             - kube_state_metrics_reachable
-            - node_exporter_reachable
             - prometheus_version
             - scrape_cfg
         - name: pre-stop

--- a/charts/cloudzero-agent/values.yaml
+++ b/charts/cloudzero-agent/values.yaml
@@ -51,8 +51,6 @@ kube-state-metrics:
   enabled: false
   extraArgs:
     - --metric-labels-allowlist=pods=[app.kubernetes.io/component]
-prometheus-node-exporter:
-  enabled: false
 
 # -- Annotations to be added to the Secret, if the chart is configured to create one
 secretAnnotations: {}
@@ -62,12 +60,11 @@ imagePullSecrets: []
 validator:
   serviceEndpoints:
     kubeStateMetrics:
-    prometheusNodeExporter:
   # -- Flag to skip validator failure if unable to connect to the CloudZero API.
   name: env-validator
   image:
     repository: ghcr.io/cloudzero/cloudzero-agent-validator/cloudzero-agent-validator
-    tag: 0.4.1
+    tag: 0.8.0
     digest:
     pullPolicy: Always
 


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [CloudZero Code of Conduct](https://github.com/cloudzero/template-cloudzero-open-source/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/cloudzero/template-cloudzero-open-source/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

I basically just did a `git grep -iP 'node.?exporter'`, and removed all the references it found.

The bump in the cloudzero-agent-validator is to pull in 934dceec3f9d45db4a877de787021f4e02025846, which removes the need for node-exporter in that project.  Without it, the validator will fail with a "missing Prometheus Node Exporter Service Endpoint" error.

### Testing

> Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
>
> Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.
>
> Also include details of the environment this PR was developed in (language/platform/browser version).

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`