### PR TITLE
CP-23740 (Feature/1.0.3 beta release): Validate KSM Metrics at Install

### DIFF
--- a/charts/cloudzero-agent/Chart.yaml
+++ b/charts/cloudzero-agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cloudzero-agent
 description: A chart for using Prometheus in agent mode to send cluster metrics to the CloudZero platform.
 type: application
-version: 1.0.3-beta
+version: 1.0.2-beta
 maintainers:
   - name: CloudZero
     email: support@cloudzero.com

--- a/charts/cloudzero-agent/Chart.yaml
+++ b/charts/cloudzero-agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cloudzero-agent
 description: A chart for using Prometheus in agent mode to send cluster metrics to the CloudZero platform.
 type: application
-version: 1.0.2-beta
+version: 1.0.3-beta
 maintainers:
   - name: CloudZero
     email: support@cloudzero.com

--- a/charts/cloudzero-agent/Chart.yaml
+++ b/charts/cloudzero-agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cloudzero-agent
 description: A chart for using Prometheus in agent mode to send cluster metrics to the CloudZero platform.
 type: application
-version: 1.0.2-beta
+version: 0.0.0-dev
 maintainers:
   - name: CloudZero
     email: support@cloudzero.com

--- a/charts/cloudzero-agent/docs/releases/1.0.3-beta.md
+++ b/charts/cloudzero-agent/docs/releases/1.0.3-beta.md
@@ -1,0 +1,13 @@
+## [1.0.3-beta](https://github.com/Cloudzero/cloudzero-agent/compare/v1.0.1-beta...v1.0.3-beta) (2024-11-20)
+
+The Agent now validates the existence of all required KSM metrics during the `post-start` phase.
+
+### Upgrade Steps
+* Upgrade with:
+```sh
+helm upgrade --install <RELEASE_NAME> cloudzero-beta/cloudzero-agent -n <NAMESPACE> --create-namespace -f configuration.example.yaml --version 1.0.3-beta
+```
+See the [beta installation instructions](https://github.com/Cloudzero/cloudzero-charts/blob/develop/charts/cloudzero-agent/BETA-INSTALLATION.md) for further detail
+
+### Improvements
+* The Validator check (kube_state_metrics_reachable) now validates the existence of all required KSM metrics.

--- a/charts/cloudzero-agent/templates/validatorcm.yaml
+++ b/charts/cloudzero-agent/templates/validatorcm.yaml
@@ -61,7 +61,7 @@ data:
           checks:
             - k8s_version
             - kube_state_metrics_reachable
-            - node_exporter_reachable
+            #- node_exporter_reachable
             - prometheus_version
             - scrape_cfg
         - name: pre-stop

--- a/charts/cloudzero-agent/templates/validatorcm.yaml
+++ b/charts/cloudzero-agent/templates/validatorcm.yaml
@@ -42,9 +42,7 @@ data:
       {{- end }}
       executable: /bin/prometheus
       kube_metrics:
-        {{- range .Values.kubeMetrics }}
-        - {{ . }}
-        {{- end }}
+        {{- toYaml .Values.kubeMetrics | nindent 8 }}
       configurations:
         - /etc/prometheus/prometheus.yml
         - /etc/config/prometheus/configmaps/prometheus.yml

--- a/charts/cloudzero-agent/templates/validatorcm.yaml
+++ b/charts/cloudzero-agent/templates/validatorcm.yaml
@@ -33,7 +33,7 @@ data:
       {{- if .Values.validator.serviceEndpoints.kubeStateMetrics }}
       kube_state_metrics_service_endpoint: http://{{ .Values.validator.serviceEndpoints.kubeStateMetrics }}/
       {{- else }}
-      kube_state_metrics_service_endpoint: http://{{- if .Release.Name }}{{.Release.Name}}-{{- end }}state-metrics:8080/
+      kube_state_metrics_endpoint: http://{{ .Values.kubeStateMetrics.nameOverride }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.kubeStateMetrics.service.port }}
       {{- end }}
       {{- if .Values.validator.serviceEndpoints.prometheusNodeExporter }}
       prometheus_node_exporter_service_endpoint: http://{{ .Values.validator.serviceEndpoints.prometheusNodeExporter }}/
@@ -41,6 +41,10 @@ data:
       prometheus_node_exporter_service_endpoint: http://{{- if .Release.Name }}{{.Release.Name}}-{{- end }}prometheus-node-exporter:9100/
       {{- end }}
       executable: /bin/prometheus
+      kube_metrics:
+        {{- range .Values.kubeMetrics }}
+        - {{ . }}
+        {{- end }}
       configurations:
         - /etc/prometheus/prometheus.yml
         - /etc/config/prometheus/configmaps/prometheus.yml

--- a/charts/cloudzero-agent/templates/validatorcm.yaml
+++ b/charts/cloudzero-agent/templates/validatorcm.yaml
@@ -33,7 +33,7 @@ data:
       {{- if .Values.validator.serviceEndpoints.kubeStateMetrics }}
       kube_state_metrics_service_endpoint: http://{{ .Values.validator.serviceEndpoints.kubeStateMetrics }}/
       {{- else }}
-      kube_state_metrics_endpoint: http://{{ .Values.kubeStateMetrics.nameOverride }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.kubeStateMetrics.service.port }}
+      kube_state_metrics_service_endpoint: http://{{ .Values.kubeStateMetrics.nameOverride }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.kubeStateMetrics.service.port }}
       {{- end }}
       {{- if .Values.validator.serviceEndpoints.prometheusNodeExporter }}
       prometheus_node_exporter_service_endpoint: http://{{ .Values.validator.serviceEndpoints.prometheusNodeExporter }}/

--- a/charts/cloudzero-agent/values.yaml
+++ b/charts/cloudzero-agent/values.yaml
@@ -22,7 +22,6 @@ kubeMetrics:
   - kube_pod_container_resource_requests
   - kube_pod_labels
   - kube_pod_info
-  - node_dmi_info
 containerMetrics:
   - container_cpu_usage_seconds_total
   - container_memory_working_set_bytes

--- a/charts/cloudzero-agent/values.yaml
+++ b/charts/cloudzero-agent/values.yaml
@@ -83,8 +83,8 @@ validator:
   name: env-validator
   image:
     repository: ghcr.io/cloudzero/cloudzero-agent-validator/cloudzero-agent-validator
-    tag: 0.4.1
-    digest:
+    tag: dev-59de324ea9e4488dd12280a3cb5a4575933b5336
+    digest: sha256:41070957cfba55065243abc61023695f046bc42b6a2bfb83db62a77942cd11a8
     pullPolicy: Always
 
 server:

--- a/charts/cloudzero-agent/values.yaml
+++ b/charts/cloudzero-agent/values.yaml
@@ -83,8 +83,8 @@ validator:
   name: env-validator
   image:
     repository: ghcr.io/cloudzero/cloudzero-agent-validator/cloudzero-agent-validator
-    tag: dev-59de324ea9e4488dd12280a3cb5a4575933b5336
-    digest: sha256:41070957cfba55065243abc61023695f046bc42b6a2bfb83db62a77942cd11a8
+    tag: 0.9.0
+    digest:
     pullPolicy: Always
 
 server:

--- a/charts/cloudzero-insights-controller/Chart.yaml
+++ b/charts/cloudzero-insights-controller/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cloudzero-insights-controller
 description: Provides telemetry to the CloudZero platform to enabling complex cost allocation and analysis.
 type: application
-version: 1.0.2-beta
+version: 0.0.0-dev
 appVersion: "0.0.2"
 dependencies:
   - name: cert-manager

--- a/charts/cloudzero-insights-controller/Chart.yaml
+++ b/charts/cloudzero-insights-controller/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cloudzero-insights-controller
 description: Provides telemetry to the CloudZero platform to enabling complex cost allocation and analysis.
 type: application
-version: 1.0.3-beta
+version: 1.0.2-beta
 appVersion: "0.0.2"
 dependencies:
   - name: cert-manager

--- a/charts/cloudzero-insights-controller/Chart.yaml
+++ b/charts/cloudzero-insights-controller/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cloudzero-insights-controller
 description: Provides telemetry to the CloudZero platform to enabling complex cost allocation and analysis.
 type: application
-version: 1.0.2-beta
+version: 1.0.3-beta
 appVersion: "0.0.2"
 dependencies:
   - name: cert-manager


### PR DESCRIPTION
This PR modifies the `kube_state_metrics_reachable` command by including the full list of KSM metrics passed by the chart, rather than the hardcoded subset used during testing.

The base branch is `feature/1.0.2-beta-release` since these changes will be for beta `1.0.3`.

**Testing**
Below is the output of the CloudZero Agent Server `post-start` job. If you notice, the logs outline the metrics being validated, eventually leading to a passing status for `kube_state_metrics_reachable`:
``` json
{
  "level": "info",
  "log_sequence": 1,
  "msg": "Using endpoint URL: http://cloudzero-state-metrics.prom-agent.svc.cluster.local:8080/metrics",
  "op": "ksm",
  "time": "2024-12-03T21:52:29Z"
}
{
  "level": "error",
  "log_sequence": 2,
  "msg": "Failed to fetch metrics on attempt 1: Get \"http://cloudzero-state-metrics.prom-agent.svc.cluster.local:8080/metrics\": dial tcp 10.100.123.115:8080: connect: connection refused",
  "op": "ksm",
  "time": "2024-12-03T21:52:29Z"
}
{
  "level": "info",
  "log_sequence": 3,
  "msg": "Found required metric kube_node_info on attempt 2",
  "op": "ksm",
  "time": "2024-12-03T21:52:39Z"
}
{
  "level": "info",
  "log_sequence": 4,
  "msg": "Found required metric kube_node_status_capacity on attempt 2",
  "op": "ksm",
  "time": "2024-12-03T21:52:39Z"
}
{
  "level": "info",
  "log_sequence": 5,
  "msg": "Found required metric kube_pod_container_resource_limits on attempt 2",
  "op": "ksm",
  "time": "2024-12-03T21:52:39Z"
}
{
  "level": "info",
  "log_sequence": 6,
  "msg": "Found required metric kube_pod_container_resource_requests on attempt 2",
  "op": "ksm",
  "time": "2024-12-03T21:52:39Z"
}
{
  "level": "info",
  "log_sequence": 7,
  "msg": "Found required metric kube_pod_labels on attempt 2",
  "op": "ksm",
  "time": "2024-12-03T21:52:39Z"
}
{
  "level": "info",
  "log_sequence": 8,
  "msg": "Found required metric kube_pod_info on attempt 2",
  "op": "ksm",
  "time": "2024-12-03T21:52:39Z"
}
{
  "level": "info",
  "log_sequence": 9,
  "msg": "reporting status",
  "report": "{
    ...
  {\"name\":\"prometheus_version\",\"passing\":true},{\"name\":\"kube_state_metrics_reachable\",\"passing\":true}]}",
  "time": "2024-12-03T21:52:39Z"
}
{
  "level": "info",
  "log_sequence": 10,
  "msg": "marshalled cluster status: 5683 bytes",
  "time": "2024-12-03T21:52:39Z"
}
{
  "level": "info",
  "log_sequence": 11,
  "msg": "compressed size is: 5683 bytes",
  "time": "2024-12-03T21:52:39Z"
}


```

### Checklist

- [x] I have added documentation for new/changed functionality in this PR
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`