### PR TITLE
[CP-23429] merge insights-controller into main chart

### DIFF
--- a/.github/workflows/test-chart.yml
+++ b/.github/workflows/test-chart.yml
@@ -36,6 +36,7 @@ jobs:
         env:
           # Agent Chart settings (prom repo is to work around issue with chart-testing tool)
           PROM_CHART_REPO: https://prometheus-community.github.io/helm-charts
+          JETSTACK_CHART_REPO: https://charts.jetstack.io
           CZ_CHART_REPO: https://cloudzero.github.io/cloudzero-charts
           CZ_CHART_BETA_REPO: https://cloudzero.github.io/cloudzero-charts/beta
           CLUSTER_NAME: cz-node-agent-ci
@@ -47,8 +48,7 @@ jobs:
           helm dependency update
           ct lint --debug --charts . \
             --chart-repos=kube-state-metrics=$PROM_CHART_REPO \
-            --chart-repos=prometheus-node-exporter=$PROM_CHART_REPO \
-            --chart-repos=cloudzero-insights-controller=$CZ_CHART_BETA_REPO \
+            --chart-repos=cert-manager=$JETSTACK_CHART_REPO \
             --helm-lint-extra-args "--set=existingSecretName=api-token,clusterName=$CLUSTER_NAME,cloudAccountId=$CLOUD_ACCOUNT_ID,region=$REGION"
 
   # This job tests the chart on a KinD cluster

--- a/.github/workflows/test-chart.yml
+++ b/.github/workflows/test-chart.yml
@@ -111,6 +111,7 @@ jobs:
           NAMESPACE: monitoring
           # Agent Chart settings (prom repo is to work around issue with chart-testing tool)
           PROM_CHART_REPO: https://prometheus-community.github.io/helm-charts
+          JETSTACK_CHART_REPO: https://charts.jetstack.io
           CZ_CHART_REPO: https://cloudzero.github.io/cloudzero-charts
           CZ_CHART_BETA_REPO: https://cloudzero.github.io/cloudzero-charts/beta
           CLUSTER_NAME: cz-node-agent-ci
@@ -125,18 +126,15 @@ jobs:
           helm dependency update
           ct install --charts . \
             --chart-repos=kube-state-metrics=$PROM_CHART_REPO \
-            --chart-repos=prometheus-node-exporter=$PROM_CHART_REPO \
-            --chart-repos=cloudzero-insights-controller=$CZ_CHART_BETA_REPO \
+            --chart-repos=cert-manager=$JETSTACK_CHART_REPO \
             --namespace $NAMESPACE \
             --helm-extra-set-args "\
-              --set=global.existingSecretName=api-token \
+              --set=existingSecretName=api-token \
               --set=host=dev-api.cloudzero.com \
               --set=clusterName=$CLUSTER_NAME \
               --set=cloudAccountId=$CLOUD_ACCOUNT_ID \
               --set=region=$REGION \
-              --set=kube-state-metrics.enabled=true \
-              --set=prometheus-node-exporter.enabled=true \
-              --set=tags.enabled=true \
-              --set=tags.labels.enabled=true \
-              --set=tags.labels.patterns[0]='.*' \
+              --set=insightsController.enabled=true \
+              --set=insightsController.labels.enabled=true \
+              --set=insightsController.labels.patterns[0]='.*' \
               "

--- a/charts/cloudzero-agent/Chart.lock
+++ b/charts/cloudzero-agent/Chart.lock
@@ -2,5 +2,8 @@ dependencies:
 - name: kube-state-metrics
   repository: https://prometheus-community.github.io/helm-charts
   version: 5.15.3
-digest: sha256:eb6b05c226ee0bd8f052108e96efad345fad4deb7f0ec8e60d3de07db965aba0
-generated: "2024-12-06T08:20:50.444292-05:00"
+- name: cert-manager
+  repository: https://charts.jetstack.io
+  version: v1.15.3
+digest: sha256:6135d395ad03a38895bd8f1d71fb84856d76b89978b5b4250f6d154c6e33b128
+generated: "2024-12-06T14:53:41.361206-05:00"

--- a/charts/cloudzero-agent/Chart.lock
+++ b/charts/cloudzero-agent/Chart.lock
@@ -2,8 +2,5 @@ dependencies:
 - name: kube-state-metrics
   repository: https://prometheus-community.github.io/helm-charts
   version: 5.15.3
-- name: cloudzero-insights-controller
-  repository: https://cloudzero.github.io/cloudzero-charts/beta
-  version: 1.0.1-beta
-digest: sha256:3518ffb88382f3e613cc9b21aac6dc474d634b316aa69cfe7f4e85474844e54b
-generated: "2024-11-21T00:05:12.882895449Z"
+digest: sha256:eb6b05c226ee0bd8f052108e96efad345fad4deb7f0ec8e60d3de07db965aba0
+generated: "2024-12-06T08:20:50.444292-05:00"

--- a/charts/cloudzero-agent/Chart.yaml
+++ b/charts/cloudzero-agent/Chart.yaml
@@ -13,13 +13,8 @@ dependencies:
     repository: https://prometheus-community.github.io/helm-charts
     condition: kubeStateMetrics.enabled
     alias: kubeStateMetrics
-  # - name: cloudzero-insights-controller
-  #   version: "1.0.1-beta"
-  #   repository: https://cloudzero.github.io/cloudzero-charts/beta
-  #   condition: cloudzero-insights-controller.enabled
-  #   alias: tags
-  # - name: cert-manager
-  #   version: v1.15.3
-  #   repository: https://charts.jetstack.io
-  #   alias: cert-manager
-  #   condition: cert-manager.enabled
+  - name: cert-manager
+    version: v1.15.3
+    repository: https://charts.jetstack.io
+    alias: cert-manager
+    condition: cert-manager.enabled

--- a/charts/cloudzero-agent/Chart.yaml
+++ b/charts/cloudzero-agent/Chart.yaml
@@ -16,5 +16,4 @@ dependencies:
   - name: cert-manager
     version: v1.15.3
     repository: https://charts.jetstack.io
-    alias: certManager
-    condition: certManager.enabled
+    condition: cert-manager.enabled

--- a/charts/cloudzero-agent/Chart.yaml
+++ b/charts/cloudzero-agent/Chart.yaml
@@ -16,5 +16,5 @@ dependencies:
   - name: cert-manager
     version: v1.15.3
     repository: https://charts.jetstack.io
-    alias: cert-manager
-    condition: cert-manager.enabled
+    alias: certManager
+    condition: certManager.enabled

--- a/charts/cloudzero-agent/Chart.yaml
+++ b/charts/cloudzero-agent/Chart.yaml
@@ -13,8 +13,13 @@ dependencies:
     repository: https://prometheus-community.github.io/helm-charts
     condition: kubeStateMetrics.enabled
     alias: kubeStateMetrics
-  - name: cloudzero-insights-controller
-    version: "1.0.1-beta"
-    repository: https://cloudzero.github.io/cloudzero-charts/beta
-    condition: cloudzero-insights-controller.enabled
-    alias: tags
+  # - name: cloudzero-insights-controller
+  #   version: "1.0.1-beta"
+  #   repository: https://cloudzero.github.io/cloudzero-charts/beta
+  #   condition: cloudzero-insights-controller.enabled
+  #   alias: tags
+  # - name: cert-manager
+  #   version: v1.15.3
+  #   repository: https://charts.jetstack.io
+  #   alias: cert-manager
+  #   condition: cert-manager.enabled

--- a/charts/cloudzero-agent/README.md
+++ b/charts/cloudzero-agent/README.md
@@ -37,7 +37,7 @@ If installing with Helm directly, execute the following steps:
 helm repo update
 ```
 
-2. Ensure that required CRDs are installed for certificate management. If you have more specific requirements around managing TLS certificates, see the [Certificate Management](###certificate-management) section.
+2. Ensure that required CRDs are installed for certificate management. If you have more specific requirements around managing TLS certificates, see the [Certificate Management](#certificate-management) section.
 ```console
 helm install <RELEASE_NAME> cloudzero/cloudzero-agent \
     --set insightsController.webhook.issuer.enabled=false \

--- a/charts/cloudzero-agent/README.md
+++ b/charts/cloudzero-agent/README.md
@@ -104,8 +104,8 @@ There are several mandatory values that must be specified for the chart to insta
 | cloudAccountId    | string | `nil`                 | Account ID in AWS or Subscription ID in Azure or Project Number in GCP where the cluster is running. Must be a string due to Helm limitations.  |
 | clusterName       | string | `nil`                 | Name of the cluster. Must be RFC 1123 compliant.                                                                         |
 | host              | string | `"api.cloudzero.com"` | CloudZero host to send metrics to.                                                                                      |
-| global.apiKey            | string | `nil`                 | The CloudZero API key to use for exporting metrics. Only used if `global.existingSecretName` is not set.                       |
-| global.existingSecretName| string | `nil`                 | Name of the secret that contains the CloudZero API key. Required if not providing the API key via `apiKey`.             |
+| apiKey            | string | `nil`                 | The CloudZero API key to use for exporting metrics. Only used if `global.existingSecretName` is not set.                       |
+| existingSecretName| string | `nil`                 | Name of the secret that contains the CloudZero API key. Required if not providing the API key via `apiKey`.             |
 | region            | string | `nil`                 | Region where the cluster is running (e.g., `us-east-1`, `eastus`). For more information, see AWS or Azure documentation. |
 | tags.labels.enabled            | string | `nil`                 | If enabled, labels for pods, deployments, statefulsets, daemonsets, cronjobs, jobs, nodes, and namespaces |
 | tags.labels.patterns            | string | `nil`                 | An array of regular expressions, which are used to match specific label keys |

--- a/charts/cloudzero-agent/README.md
+++ b/charts/cloudzero-agent/README.md
@@ -40,9 +40,9 @@ helm repo update
 2. Ensure that required CRDs are installed for certifiacte management. If you have more specific requirements around managing TLS certificates, see the [Certificate Management](https://github.com/Cloudzero/cloudzero-charts/tree/develop/charts/cloudzero-insights-controller#deployment-configurations-and-certificate-management) section in the `cloudzero-insights-controller` subchart.
 ```console
 helm install <RELEASE_NAME> cloudzero/cloudzero-agent \
-    --set tags.webhook.issuer.enabled=false \
-    --set tags.webhook.certificate.enabled=false \
-    --set tags.cert-manager.installCRDs=true
+    --set insightsController.webhook.issuer.enabled=false \
+    --set insightsController.webhook.certificate.enabled=false \
+    --set insightsController.cert-manager.installCRDs=true
 ```
 
 3. Fill out all required fields in the `configuration.example.yaml` file in this directory. Rename the file as necessary. Below is an example of a completed configuration file:

--- a/charts/cloudzero-agent/README.md
+++ b/charts/cloudzero-agent/README.md
@@ -37,13 +37,14 @@ If installing with Helm directly, execute the following steps:
 helm repo update
 ```
 
-2. Ensure that required CRDs are installed for certifiacte management. If you have more specific requirements around managing TLS certificates, see the [Certificate Management](https://github.com/Cloudzero/cloudzero-charts/tree/develop/charts/cloudzero-insights-controller#deployment-configurations-and-certificate-management) section in the `cloudzero-insights-controller` subchart.
+2. Ensure that required CRDs are installed for certificate management. If you have more specific requirements around managing TLS certificates, see the [Certificate Management](###certificate-management) section.
 ```console
 helm install <RELEASE_NAME> cloudzero/cloudzero-agent \
     --set insightsController.webhook.issuer.enabled=false \
     --set insightsController.webhook.certificate.enabled=false \
     --set insightsController.cert-manager.installCRDs=true
 ```
+Alternatively, [install the cert-manager CRDs directly](https://cert-manager.io/docs/installation/helm/).
 
 3. Fill out all required fields in the `configuration.example.yaml` file in this directory. Rename the file as necessary. Below is an example of a completed configuration file:
 ```yaml
@@ -53,14 +54,13 @@ cloudAccountId: YOUR_CLOUD_ACCOUNT_ID
 clusterName: YOUR_CLUSTER_NAME
 # -- Region the cluster is running in.
 region: YOUR_CLOUD_REGION
-global:
-  # -- CloudZero API key. Required if useExistingSecret is false.
-  apiKey: YOUR_CLOUDZERO_API_KEY
-  # -- If set, the agent will use the API key in this Secret to authenticate with CloudZero.
-  existingSecretName: YOUR_EXISTING_API_KEY_K8S_SECRET
+# -- CloudZero API key. Required if useExistingSecret is false.
+apiKey: YOUR_CLOUDZERO_API_KEY
+# -- If set, the agent will use the API key in this Secret to authenticate with CloudZero.
+existingSecretName: YOUR_EXISTING_API_KEY_K8S_SECRET
 
-# label and annotation configuration (referred together as 'tags'). See the below 'Labels and Annotations' section for more details.
-tags:
+# label and annotation configuration (managed in the 'insightsController' section). See the below 'Labels and Annotations' section for more details.
+insightsController:
   # -- By default, a ValidatingAdmissionWebhook will be deployed that records all created labels and annotations
   enabled: true
   labels:
@@ -68,13 +68,13 @@ tags:
     enabled: true
     # -- This value MUST be set to a list of regular expressions which will be used to gather labels from pods, deployments, statefulsets, daemonsets, cronjobs, jobs, nodes, and namespaces
     patterns:
-      - '^foo' # -- match all labels whose key starts with "foo"
-      - 'bar$' # -- match all labels whose key ends with "bar"
+      - '^foo' # -- Match all labels whose key starts with "foo"
+      - 'bar$' # -- Match all labels whose key ends with "bar"
   annotations:
     # -- By default, the gathering of annotations is not enabled. To enable, set this field to true
     enabled: false
     patterns:
-      - '.*'
+      - '.*' # -- match all annotations. This is not recommended.
 ```
 
 4. Install the helm chart using the completed configuration file:
@@ -107,8 +107,8 @@ There are several mandatory values that must be specified for the chart to insta
 | apiKey            | string | `nil`                 | The CloudZero API key to use for exporting metrics. Only used if `global.existingSecretName` is not set.                       |
 | existingSecretName| string | `nil`                 | Name of the secret that contains the CloudZero API key. Required if not providing the API key via `apiKey`.             |
 | region            | string | `nil`                 | Region where the cluster is running (e.g., `us-east-1`, `eastus`). For more information, see AWS or Azure documentation. |
-| tags.labels.enabled            | string | `nil`                 | If enabled, labels for pods, deployments, statefulsets, daemonsets, cronjobs, jobs, nodes, and namespaces |
-| tags.labels.patterns            | string | `nil`                 | An array of regular expressions, which are used to match specific label keys |
+| insightsController.labels.enabled            | string | `nil`                 | If enabled, labels for pods, deployments, statefulsets, daemonsets, cronjobs, jobs, nodes, and namespaces |
+| insightsController.labels.patterns            | string | `nil`                 | An array of regular expressions, which are used to match specific label keys |
 
 #### Overriding Default Values
 
@@ -133,7 +133,7 @@ You can use the `--set` flag in Helm commands to directly set or override specif
 
 ```console
 helm install <RELEASE_NAME> cloudzero/cloudzero-agent \
-    --set global.existingSecretName=<NAME_OF_SECRET> \
+    --set existingSecretName=<NAME_OF_SECRET> \
     --set clusterName=<CLUSTER_NAME> \
     --set-string cloudAccountId=<CLOUD_ACCOUNT_ID> \
     --set region=<REGION> \
@@ -154,11 +154,17 @@ This chart allows the exporting of labels and annotations from the following res
 - `Namespace`
 
 Additional Notes:
-- By default, only labels from pods and namespaces are exported. To enabled more resources, see the `webhooks.configurations` section of the `values.yaml` file.
-- Labels and annotations exports are managed by a subchart, `cloudzero-insights-controller`, which is also maintained in this repository.
+- By default, only labels from pods and namespaces are exported. To enable more resources, see the `insightsController.labels.resources` and `insightsController.annotations.resources` section of the `values.yaml` file.
+- Labels and annotations exports are managed in the `insightsController` section of the `values.yaml` file.
 - To disambiguate labels/annotations between resources, a prefix representing the resource type is prepended to the label key in the Explorer page. For example, a `foo=bar` node label would be presented as `node:foo: bar`. The exception is pod labels which do not have resource prefixes for backward compatibility with previous versions.
-- Annotations are not exported by default; see the `tags.annotations.enabled` setting to enable. To disambiguate annotations from labels, an `annotation` prefix is prepended to the annotation key; i.e., an `foo: bar` annotation on a namespace would be represented in the Explorer as `node:annotation:foo: bar`
-- For both labels and annotations, the `enabled` flag applies across all resource types; i.e., setting `true` for `tags.labels.enabled` enabels label exporting for labels on pods, nodes, deployments, statefulsets, namespaces, daemonets, jobs, and cronjobs. Specific resources can be disabled by altering the `webhooks.configurations` configuration.
+- Annotations are not exported by default; see the `insightsController.annotations.enabled` setting to enable. To disambiguate annotations from labels, an `annotation` prefix is prepended to the annotation key; i.e., an `foo: bar` annotation on a namespace would be represented in the Explorer as `node:annotation:foo: bar`
+- For both labels and annotations, the `patterns` array applies across all resource types; i.e., setting `['^foo']` for `insightsController.labels.patterns` will match label keys that start with `foo` for all resource types set to `true` in `insightsController.labels.resources`.
+
+### Certificate Management
+
+This chart contains a `ValidatingWebhookConfiguration` resource, which requires a certificate in order validate requests to the webhook server. See related Kubernetes documentation [here](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#configure-admission-webhooks-on-the-fly).
+
+The default behavior of the chart is to deploy [cert-manager](https://github.com/cert-manager/cert-manager/tree/master) to create and manage the certificate.
 
 ### Secret Management
 

--- a/charts/cloudzero-agent/configuration.example.yaml
+++ b/charts/cloudzero-agent/configuration.example.yaml
@@ -12,7 +12,7 @@ global:
   existingSecretName: null
 
 # label and annotation configuration:
-tags:
+insightsController:
   # -- By default, a ValidatingAdmissionWebhook will be deployed that records all created labels and annotations
   enabled: true
   labels:

--- a/charts/cloudzero-agent/templates/_helpers.tpl
+++ b/charts/cloudzero-agent/templates/_helpers.tpl
@@ -173,17 +173,17 @@ Insights Controller
 {{/*
 Create common matchLabels for webhook server
 */}}
-{{- define "cloudzero-agent.tags.common.matchLabels" -}}
+{{- define "cloudzero-agent.insightsController.common.matchLabels" -}}
 app.kubernetes.io/name: {{ include "cloudzero-agent.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
-{{- define "cloudzero-agent.tags.server.matchLabels" -}}
-app.kubernetes.io/component: {{ .Values.tags.server.name }}
+{{- define "cloudzero-agent.insightsController.server.matchLabels" -}}
+app.kubernetes.io/component: {{ .Values.insightsController.server.name }}
 {{ include "cloudzero-agent.common.matchLabels" . }}
 {{- end -}}
 
-{{- define "cloudzero-agent.tags.initJob.matchLabels" -}}
+{{- define "cloudzero-agent.insightsController.initJob.matchLabels" -}}
 app.kubernetes.io/component: {{ include "cloudzero-agent.initJobName" . }}
 {{ include "cloudzero-agent.common.matchLabels" . }}
 {{- end -}}
@@ -194,12 +194,12 @@ Service selector labels
 */}}
 {{- define "cloudzero-agent.selectorLabels" -}}
 {{ include "cloudzero-agent.common.matchLabels" . }}
-{{ include "cloudzero-agent.tags.server.matchLabels" . }}
+{{ include "cloudzero-agent.insightsController.server.matchLabels" . }}
 {{- end }}
 
 
-{{- define "cloudzero-agent.tags.labels" -}}
-{{ include "cloudzero-agent.tags.server.matchLabels" . }}
+{{- define "cloudzero-agent.insightsController.labels" -}}
+{{ include "cloudzero-agent.insightsController.server.matchLabels" . }}
 {{ include "cloudzero-agent.common.metaLabels" . }}
 {{- end -}}
 
@@ -208,15 +208,15 @@ Service selector labels
 Create a fully qualified webhook server name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
-{{- define "cloudzero-agent.tags.server.webhookFullname" -}}
+{{- define "cloudzero-agent.insightsController.server.webhookFullname" -}}
 {{- if .Values.server.fullnameOverride -}}
 {{- .Values.server.fullnameOverride | trunc 63 | trimSuffix "-" -}}-webhook
 {{- else -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- if contains $name .Release.Name -}}
-{{- printf "%s-%s" .Release.Name .Values.tags.server.name | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s-%s" .Release.Name .Values.insightsController.server.name | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
-{{- printf "%s-%s-%s" .Release.Name $name .Values.tags.server.name | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s-%s-%s" .Release.Name $name .Values.insightsController.server.name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}
@@ -226,47 +226,47 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 Name for the webhook server service
 */}}
 {{- define "cloudzero-agent.serviceName" -}}
-{{- printf "%s-svc" (include "cloudzero-agent.tags.server.webhookFullname" .) }}
+{{- printf "%s-svc" (include "cloudzero-agent.insightsController.server.webhookFullname" .) }}
 {{- end }}
 
 {{/*
 Name for the validating webhook configuration resource
 */}}
 {{- define "cloudzero-agent.validatingWebhookConfigName" -}}
-{{- printf "%s-webhook" (include "cloudzero-agent.tags.server.webhookFullname" .) }}
+{{- printf "%s-webhook" (include "cloudzero-agent.insightsController.server.webhookFullname" .) }}
 {{- end }}
 
 {{/*
 Name for the certificate secret
 */}}
 {{- define "cloudzero-agent.tlsSecretName" -}}
-{{- printf "%s-tls" (include "cloudzero-agent.tags.server.webhookFullname" .) }}
+{{- printf "%s-tls" (include "cloudzero-agent.insightsController.server.webhookFullname" .) }}
 {{- end }}
 
 
 {{ define "cloudzero-agent.webhookConfigMapName" -}}
-{{ .Values.tags.ConfigMapNameOverride | default (printf "%s-webhook-configuration" .Release.Name) }}
+{{ .Values.insightsController.ConfigMapNameOverride | default (printf "%s-webhook-configuration" .Release.Name) }}
 {{- end}}
 
 {{/*
 Mount path for the insights server configuration file
 */}}
-{{- define "cloudzero-agent.tags.configurationMountPath" -}}
-{{- default .Values.tags.configurationMountPath (printf "/etc/%s-insights" .Chart.Name)  }}
+{{- define "cloudzero-agent.insightsController.configurationMountPath" -}}
+{{- default .Values.insightsController.configurationMountPath (printf "/etc/%s-insights" .Chart.Name)  }}
 {{- end }}
 
 {{/*
 Name for the issuer resource
 */}}
 {{- define "cloudzero-agent.issuerName" -}}
-{{- printf "%s-issuer" (include "cloudzero-agent.tags.server.webhookFullname" .) }}
+{{- printf "%s-issuer" (include "cloudzero-agent.insightsController.server.webhookFullname" .) }}
 {{- end }}
 
 {{/*
 Name for the job resource
 */}}
 {{- define "cloudzero-agent.initJobName" -}}
-{{- printf "%s-init" (include "cloudzero-agent.tags.server.webhookFullname" .) }}
+{{- printf "%s-init" (include "cloudzero-agent.insightsController.server.webhookFullname" .) }}
 {{- end }}
 
 
@@ -286,5 +286,5 @@ cert-manager.io/inject-ca-from: {{ .Values.webhook.caInjection | default (printf
 Name for the certificate resource
 */}}
 {{- define "cloudzero-agent.certificateName" -}}
-{{- printf "%s-certificate" (include "cloudzero-agent.tags.server.webhookFullname" .) }}
+{{- printf "%s-certificate" (include "cloudzero-agent.insightsController.server.webhookFullname" .) }}
 {{- end }}

--- a/charts/cloudzero-agent/templates/_helpers.tpl
+++ b/charts/cloudzero-agent/templates/_helpers.tpl
@@ -234,7 +234,7 @@ Mount path for the insights server configuration file
 {{- default .Values.tags.configurationMountPath (printf "/etc/%s-insights" .Chart.Name)  }}
 {{- end }}
 
-{{- define "cloudzero-agent.tags.server.labels" -}}
+{{- define "cloudzero-agent.tags.labels" -}}
 {{ include "cloudzero-agent.tags.server.matchLabels" . }}
 app.kubernetes.io/name: {{ include "cloudzero-agent.tags.server.webhookFullname" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/cloudzero-agent/templates/_helpers.tpl
+++ b/charts/cloudzero-agent/templates/_helpers.tpl
@@ -22,6 +22,13 @@ Create chart name and version as used by the chart label.
 {{ printf "%s%s" .Values.server.containerSecretFilePath .Values.server.containerSecretFileName }}
 {{- end}}
 
+{{/*
+Name for the certificate secret
+*/}}
+{{- define "cloudzero-agent.tlsSecretName" -}}
+{{- printf "%s-tls" (include "cloudzero-agent.tags.server.webhookFullname" .) }}
+{{- end }}
+
 {{ define "cloudzero-agent.configMapName" -}}
 {{ .Values.configMapNameOverride | default (printf "%s-configuration" .Release.Name) }}
 {{- end}}
@@ -29,6 +36,13 @@ Create chart name and version as used by the chart label.
 {{ define "cloudzero-agent.cloudzeroConfigMapName" -}}
 {{ .Values.cloudzeroConfigMapNameOverride | default (printf "%s-cloudzero-configuration" .Release.Name) }}
 {{- end}}
+
+{{/*
+Mount path for the insights server configuration file
+*/}}
+{{- define "cloudzero-agent.tags.configurationMountPath" -}}
+{{- default .Values.tags.configurationMountPath (printf "/etc/%s-insights" .Chart.Name)  }}
+{{- end }}
 
 {{ define "cloudzero-agent.validatorConfigMapName" -}}
 {{- printf "%s-validator-configuration" .Release.Name -}}
@@ -57,6 +71,12 @@ app.kubernetes.io/component: {{ .Values.server.name }}
 {{ include "cloudzero-agent.common.matchLabels" . }}
 {{- end -}}
 
+{{- define "cloudzero-agent.tags.server.matchLabels" -}}
+app.kubernetes.io/component: {{ .Values.tags.server.name }}
+{{ include "cloudzero-agent.common.matchLabels" . }}
+{{- end -}}
+
+
 {{/*
 Create unified labels for prometheus components
 */}}
@@ -75,6 +95,11 @@ app.kubernetes.io/part-of: {{ include "cloudzero-agent.name" . }}
 {{ include "cloudzero-agent.common.metaLabels" . }}
 {{- end -}}
 
+{{- define "cloudzero-agent.tags.server.labels" -}}
+{{ include "cloudzero-agent.tags.server.matchLabels" . }}
+{{ include "cloudzero-agent.common.metaLabels" . }}
+{{- end -}}
+
 
 {{/*
 Define the cloudzero-agent.namespace template if set with forceNamespace or .Release.Namespace is set
@@ -86,11 +111,11 @@ Define the cloudzero-agent.namespace template if set with forceNamespace or .Rel
 {{/*
 Create the name of the service account to use for the server component
 */}}
-{{- define "cloudzero-agent.serviceAccountName.server" -}}
-{{- if .Values.serviceAccounts.server.create -}}
-    {{ default (include "cloudzero-agent.server.fullname" .) .Values.serviceAccounts.server.name }}
+{{- define "cloudzero-agent.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "cloudzero-agent.server.fullname" .) .Values.serviceAccount.name }}
 {{- else -}}
-    {{ default "default" .Values.serviceAccounts.server.name }}
+    {{ default "default" .Values.server.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
 
@@ -107,6 +132,24 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- printf "%s-%s" .Release.Name .Values.server.name | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
 {{- printf "%s-%s-%s" .Release.Name $name "server" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+
+{{/*
+Create a fully qualified webhook server name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "cloudzero-agent.tags.server.webhookFullname" -}}
+{{- if .Values.server.fullnameOverride -}}
+{{- .Values.server.fullnameOverride | trunc 63 | trimSuffix "-" -}}-webhook
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- printf "%s-%s" .Release.Name .Values.tags.server.name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s-%s" .Release.Name $name .Values.tags.server.name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/cloudzero-agent/templates/_helpers.tpl
+++ b/charts/cloudzero-agent/templates/_helpers.tpl
@@ -60,9 +60,6 @@ app.kubernetes.io/component: {{ .Values.server.name }}
 {{ include "cloudzero-agent.common.matchLabels" . }}
 {{- end -}}
 
-
-
-
 {{/*
 Create unified labels for prometheus components
 */}}
@@ -80,7 +77,6 @@ app.kubernetes.io/part-of: {{ include "cloudzero-agent.name" . }}
 {{ include "cloudzero-agent.server.matchLabels" . }}
 {{ include "cloudzero-agent.common.metaLabels" . }}
 {{- end -}}
-
 
 {{/*
 Define the cloudzero-agent.namespace template if set with forceNamespace or .Release.Namespace is set
@@ -116,9 +112,6 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 {{- end -}}
 {{- end -}}
-
-
-
 
 {{/*
 Return the appropriate apiVersion for rbac.
@@ -164,10 +157,8 @@ Required metric labels
 {{- end -}}
 
 
-
 {{/*
 Insights Controller
-
 */}}
 
 {{/*
@@ -188,7 +179,6 @@ app.kubernetes.io/component: {{ include "cloudzero-agent.initJobName" . }}
 {{ include "cloudzero-agent.common.matchLabels" . }}
 {{- end -}}
 
-
 {{/*
 Service selector labels
 */}}
@@ -197,12 +187,10 @@ Service selector labels
 {{ include "cloudzero-agent.insightsController.server.matchLabels" . }}
 {{- end }}
 
-
 {{- define "cloudzero-agent.insightsController.labels" -}}
 {{ include "cloudzero-agent.insightsController.server.matchLabels" . }}
 {{ include "cloudzero-agent.common.metaLabels" . }}
 {{- end -}}
-
 
 {{/*
 Create a fully qualified webhook server name.
@@ -220,7 +208,6 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 {{- end -}}
 {{- end -}}
-
 
 {{/*
 Name for the webhook server service
@@ -268,7 +255,6 @@ Name for the job resource
 {{- define "cloudzero-agent.initJobName" -}}
 {{- printf "%s-init" (include "cloudzero-agent.insightsController.server.webhookFullname" .) }}
 {{- end }}
-
 
 {{/*
 Annotations for the webhooks

--- a/charts/cloudzero-agent/templates/_helpers.tpl
+++ b/charts/cloudzero-agent/templates/_helpers.tpl
@@ -240,3 +240,18 @@ app.kubernetes.io/name: {{ include "cloudzero-agent.tags.server.webhookFullname"
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{ include "cloudzero-agent.common.metaLabels" . }}
 {{- end -}}
+
+
+{{/*
+Name for the issuer resource
+*/}}
+{{- define "cloudzero-agent.issuerName" -}}
+{{- printf "%s-issuer" (include "cloudzero-agent.tags.server.webhookFullname" .) }}
+{{- end }}
+
+{{/*
+Name for the job resource
+*/}}
+{{- define "cloudzero-agent.initJobName" -}}
+{{- printf "%s-init" (include "cloudzero-agent.tags.server.webhookFullname" .) }}
+{{- end }}

--- a/charts/cloudzero-agent/templates/_helpers.tpl
+++ b/charts/cloudzero-agent/templates/_helpers.tpl
@@ -255,3 +255,23 @@ Name for the job resource
 {{- define "cloudzero-agent.initJobName" -}}
 {{- printf "%s-init" (include "cloudzero-agent.tags.server.webhookFullname" .) }}
 {{- end }}
+
+
+{{/*
+Annotations for the webhooks
+*/}}
+{{- define "cloudzero-agent.webhooks.annotations" -}}
+{{- if .Values.webhooks.annotations }}
+{{ toYaml .Values.webhook.annotations }}
+{{- end }}
+{{- if and .Values.webhook.certificate.enabled .Values.webhook.issuer.enabled }}
+cert-manager.io/inject-ca-from: {{ .Values.webhook.caInjection | default (printf "%s/%s" .Release.Namespace (include "cloudzero-agent.certificateName" .)) }}
+{{- end }}
+{{- end }}
+
+{{/*
+Name for the certificate resource
+*/}}
+{{- define "cloudzero-agent.certificateName" -}}
+{{- printf "%s-certificate" (include "cloudzero-agent.tags.server.webhookFullname" .) }}
+{{- end }}

--- a/charts/cloudzero-agent/templates/_helpers.tpl
+++ b/charts/cloudzero-agent/templates/_helpers.tpl
@@ -260,11 +260,11 @@ Name for the job resource
 Annotations for the webhooks
 */}}
 {{- define "cloudzero-agent.webhooks.annotations" -}}
-{{- if .Values.webhooks.annotations }}
-{{ toYaml .Values.webhook.annotations }}
+{{- if .Values.insightsController.webhooks.annotations }}
+{{ toYaml .Values.insightsController.webhook.annotations }}
 {{- end }}
-{{- if and .Values.webhook.certificate.enabled .Values.webhook.issuer.enabled }}
-cert-manager.io/inject-ca-from: {{ .Values.webhook.caInjection | default (printf "%s/%s" .Release.Namespace (include "cloudzero-agent.certificateName" .)) }}
+{{- if and .Values.insightsController.webhooks.certificate.enabled .Values.insightsController.webhooks.issuer.enabled }}
+cert-manager.io/inject-ca-from: {{ .Values.insightsController.webhooks.caInjection | default (printf "%s/%s" .Release.Namespace (include "cloudzero-agent.certificateName" .)) }}
 {{- end }}
 {{- end }}
 

--- a/charts/cloudzero-agent/templates/certificate.yaml
+++ b/charts/cloudzero-agent/templates/certificate.yaml
@@ -1,0 +1,28 @@
+{{ if .Values.webhook.certificate.enabled }}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "insights-controller.certificateName" . }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  secretName: {{ include "insights-controller.tlsSecretName" .}}
+  secretTemplate:
+    {{- with .Values.secretAnnotations }}
+    annotations:
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    labels:
+      {{- include "insights-controller.labels" . | nindent 6 }}
+  privateKey:
+    algorithm: RSA
+    encoding: PKCS1
+    size: 2048
+  duration: 2160h # 90d
+  renewBefore: 360h # 15d
+  dnsNames:
+    - {{ include "insights-controller.serviceName" . }}.{{ .Release.Namespace }}.svc
+  issuerRef:
+    name: {{ include "insights-controller.issuerName" . }}
+    kind: Issuer
+{{ end }}

--- a/charts/cloudzero-agent/templates/certificate.yaml
+++ b/charts/cloudzero-agent/templates/certificate.yaml
@@ -1,5 +1,4 @@
-{{ if .Values.insightsController.enabled }}
-{{ if and .Values.insightsController.webhooks.certificate.enabled (.Values.certManager.enabled) }}
+{{ if and .Values.insightsController.webhooks.certificate.enabled .Values.insightsController.enabled }}
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -26,5 +25,4 @@ spec:
   issuerRef:
     name: {{ include "cloudzero-agent.issuerName" . }}
     kind: Issuer
-{{ end }}
 {{ end }}

--- a/charts/cloudzero-agent/templates/certificate.yaml
+++ b/charts/cloudzero-agent/templates/certificate.yaml
@@ -1,19 +1,19 @@
-{{ if .Values.webhook.certificate.enabled }}
+{{ if .Values.tags.webhooks.certificate.enabled }}
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: {{ include "insights-controller.certificateName" . }}
+  name: {{ include "cloudzero-agent.certificateName" . }}
   namespace: {{ .Release.Namespace }}
 spec:
-  secretName: {{ include "insights-controller.tlsSecretName" .}}
+  secretName: {{ include "cloudzero-agent.tlsSecretName" .}}
   secretTemplate:
     {{- with .Values.secretAnnotations }}
     annotations:
     {{- toYaml . | nindent 4 }}
     {{- end }}
     labels:
-      {{- include "insights-controller.labels" . | nindent 6 }}
+      {{- include "cloudzero-agent.tags.labels" . | nindent 6 }}
   privateKey:
     algorithm: RSA
     encoding: PKCS1
@@ -21,8 +21,8 @@ spec:
   duration: 2160h # 90d
   renewBefore: 360h # 15d
   dnsNames:
-    - {{ include "insights-controller.serviceName" . }}.{{ .Release.Namespace }}.svc
+    - {{ include "cloudzero-agent.serviceName" . }}.{{ .Release.Namespace }}.svc
   issuerRef:
-    name: {{ include "insights-controller.issuerName" . }}
+    name: {{ include "cloudzero-agent.issuerName" . }}
     kind: Issuer
 {{ end }}

--- a/charts/cloudzero-agent/templates/certificate.yaml
+++ b/charts/cloudzero-agent/templates/certificate.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.tags.webhooks.certificate.enabled }}
+{{ if .Values.insightsController.webhooks.certificate.enabled }}
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -13,7 +13,7 @@ spec:
     {{- toYaml . | nindent 4 }}
     {{- end }}
     labels:
-      {{- include "cloudzero-agent.tags.labels" . | nindent 6 }}
+      {{- include "cloudzero-agent.insightsController.labels" . | nindent 6 }}
   privateKey:
     algorithm: RSA
     encoding: PKCS1

--- a/charts/cloudzero-agent/templates/certificate.yaml
+++ b/charts/cloudzero-agent/templates/certificate.yaml
@@ -1,4 +1,5 @@
-{{ if .Values.insightsController.webhooks.certificate.enabled }}
+{{ if .Values.insightsController.enabled }}
+{{ if and .Values.insightsController.webhooks.certificate.enabled (.Values.certManager.enabled) }}
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -25,4 +26,5 @@ spec:
   issuerRef:
     name: {{ include "cloudzero-agent.issuerName" . }}
     kind: Issuer
+{{ end }}
 {{ end }}

--- a/charts/cloudzero-agent/templates/clusterrole.yaml
+++ b/charts/cloudzero-agent/templates/clusterrole.yaml
@@ -7,6 +7,23 @@ metadata:
   name: {{ include "cloudzero-agent.clusterRoleName" . }}
 rules:
   - apiGroups:
+      - "apps"
+    resources:
+      - "deployments"
+      - "statefulsets"
+      - "daemonsets"
+    verbs:
+      - "get"
+      - "list"
+  - apiGroups:
+      - "batch"
+    resources:
+      - "jobs"
+      - "cronjobs"
+    verbs:
+      - "get"
+      - "list"
+  - apiGroups:
       - ""
     resources:
       - endpoints

--- a/charts/cloudzero-agent/templates/clusterrole.yaml
+++ b/charts/cloudzero-agent/templates/clusterrole.yaml
@@ -27,6 +27,7 @@ rules:
       - ""
     resources:
       - endpoints
+      - namespaces
       - nodes
       - nodes/proxy
       - nodes/metrics

--- a/charts/cloudzero-agent/templates/clusterrolebinding.yaml
+++ b/charts/cloudzero-agent/templates/clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.rbac.create (empty .Values.server.namespaces) (empty .Values.server.useExistingClusterRoleName) -}}
+{{- if and .Values.rbac.create -}}
 apiVersion: {{ template "cloudzero-agent.rbac.apiVersion" . }}
 kind: ClusterRoleBinding
 metadata:
@@ -7,7 +7,7 @@ metadata:
   name: {{ include "cloudzero-agent.clusterRoleName" . }}
 subjects:
   - kind: ServiceAccount
-    name: {{ template "cloudzero-agent.serviceAccountName.server" . }}
+    name: {{ template "cloudzero-agent.serviceAccountName" . }}
     namespace: {{ include "cloudzero-agent.namespace" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/charts/cloudzero-agent/templates/cm.yaml
+++ b/charts/cloudzero-agent/templates/cm.yaml
@@ -133,15 +133,15 @@ data:
             action: keep
         metadata_config:
           send: false
-{{- if .Values.tags.enabled }}
+{{- if .Values.insightsController.enabled }}
 ---
-{{- with .Values.tags }}
+{{- with .Values.insightsController }}
 {{- if not (and .labels.enabled .labels.patterns) }}
-{{- $msg := "\n\nThe required field(s) 'tags.labels.enabled' and/or 'tags.labels.patterns' is not set! See the README.md for more information." }}
+{{- $msg := "\n\nThe required field(s) 'insightsController.labels.enabled' and/or 'insightsController.labels.patterns' is not set! See the README.md for more information." }}
 {{- $enabledMsg:=""}}
 {{- $patternMsg:=""}}
 {{- if not .labels.enabled  }}
-{{- $enabledMsg = "Ensure that 'tags.labels.enabled' is a boolean (true or false). Set 'true' to enable exporting labels."}}
+{{- $enabledMsg = "Ensure that 'insightsController.labels.enabled' is a boolean (true or false). Set 'true' to enable exporting labels."}}
 {{- end }}
 {{- if not .labels.patterns }}
 {{- $patternMsg = "The required field 'labels.patterns' is not set or set incorrectly. It must be an array of regular expressions that match label keys to be exported."}}
@@ -178,7 +178,7 @@ data:
       cleanup_interval: 3h
       batch_update_size: 500
     api_key_path: {{ include "cloudzero-agent.secretFileFullPath" . }}
-    {{- with .Values.tags.server }}
+    {{- with .Values.insightsController.server }}
     certificate:
       key: {{ .tls.mountPath }}/tls.key
       cert: {{ .tls.mountPath }}/tls.crt
@@ -190,7 +190,7 @@ data:
     {{- end }}
     filters:
       labels:
-        {{- .Values.tags.labels | toYaml | nindent 8 }}
+        {{- .Values.insightsController.labels | toYaml | nindent 8 }}
       annotations:
-        {{- .Values.tags.annotations | toYaml | nindent 8 }}
+        {{- .Values.insightsController.annotations | toYaml | nindent 8 }}
 {{- end }}

--- a/charts/cloudzero-agent/templates/cm.yaml
+++ b/charts/cloudzero-agent/templates/cm.yaml
@@ -135,6 +135,20 @@ data:
           send: false
 {{- if .Values.tags.enabled }}
 ---
+{{- with .Values.tags }}
+{{- if not (and .labels.enabled .labels.patterns) }}
+{{- $msg := "\n\nThe required field(s) 'tags.labels.enabled' and/or 'tags.labels.patterns' is not set! See the README.md for more information." }}
+{{- $enabledMsg:=""}}
+{{- $patternMsg:=""}}
+{{- if not .labels.enabled  }}
+{{- $enabledMsg = "Ensure that 'tags.labels.enabled' is a boolean (true or false). Set 'true' to enable exporting labels."}}
+{{- end }}
+{{- if not .labels.patterns }}
+{{- $patternMsg = "The required field 'labels.patterns' is not set or set incorrectly. It must be an array of regular expressions that match label keys to be exported."}}
+{{- end }}
+{{- fail (printf "\n %s \n %s \n %s" $msg $enabledMsg $patternMsg) }}
+{{- end }}
+{{- end }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -147,9 +161,36 @@ metadata:
   {{- toYaml . | nindent 4 }}
   {{- end }}
 data:
-  cloudzero-config.yaml: |-
+  server-config.yaml: |-
     cloud_account_id: {{ .Values.cloudAccountId }}
     region: {{ .Values.region }}
     cluster_name: {{ .Values.clusterName }}
     host: {{ .Values.host }}
+    remote_write:
+      send_interval: 1m
+      max_bytes_per_send: 500000
+      send_timeout: 10s
+      max_retries: 3
+    k8s_client:
+      timeout: 30s
+    database:
+      retention_time: 24h
+      cleanup_interval: 3h
+      batch_update_size: 500
+    {{- with .Values.tags.server }}
+    certificate:
+      key: {{ .tls.mountPath }}/tls.key
+      cert: {{ .tls.mountPath }}/tls.crt
+    {{- end }}
+    api_key_path: {{ .containerSecretFilePath }}/{{ .containerSecretFileName }}
+    server:
+      port: {{ .port }}
+      read_timeout: {{ .read_timeout }}
+      write_timeout: {{ .write_timeout }}
+      idle_timeout: {{ .idle_timeout }}
+    filters:
+      labels:
+        {{- .Values.tags.labels | toYaml | nindent 8 }}
+      annotations:
+        {{- .Values.tags.annotations | toYaml | nindent 8 }}
 {{- end }}

--- a/charts/cloudzero-agent/templates/cm.yaml
+++ b/charts/cloudzero-agent/templates/cm.yaml
@@ -154,7 +154,7 @@ kind: ConfigMap
 metadata:
   labels:
     {{- include "cloudzero-agent.server.labels" . | nindent 4 }}
-  name: {{ include "cloudzero-agent.cloudzeroConfigMapName" . }}
+  name: {{ include "cloudzero-agent.webhookConfigMapName" . }}
   namespace: {{ include "cloudzero-agent.namespace" . }}
   {{- with .Values.prometheusConfig.configMapAnnotations }}
   annotations:

--- a/charts/cloudzero-agent/templates/cm.yaml
+++ b/charts/cloudzero-agent/templates/cm.yaml
@@ -177,17 +177,17 @@ data:
       retention_time: 24h
       cleanup_interval: 3h
       batch_update_size: 500
+    api_key_path: {{ include "cloudzero-agent.secretFileFullPath" . }}
     {{- with .Values.tags.server }}
     certificate:
       key: {{ .tls.mountPath }}/tls.key
       cert: {{ .tls.mountPath }}/tls.crt
-    {{- end }}
-    api_key_path: {{ .containerSecretFilePath }}/{{ .containerSecretFileName }}
     server:
       port: {{ .port }}
       read_timeout: {{ .read_timeout }}
       write_timeout: {{ .write_timeout }}
       idle_timeout: {{ .idle_timeout }}
+    {{- end }}
     filters:
       labels:
         {{- .Values.tags.labels | toYaml | nindent 8 }}

--- a/charts/cloudzero-agent/templates/deploy.yaml
+++ b/charts/cloudzero-agent/templates/deploy.yaml
@@ -41,7 +41,7 @@ spec:
           volumeMounts:
           {{- if or .Values.existingSecretName .Values.apiKey }}
             - name: cloudzero-api-key
-              mountPath: {{ .Values.server.containerSecretFilePath }}
+              mountPath: {{ .Values.serverConfig.containerSecretFilePath }}
               subPath: ""
               readOnly: true
           {{- end }}
@@ -134,7 +134,7 @@ spec:
               mountPath: /check/app/config/
           {{- if or .Values.existingSecretName .Values.apiKey }}
             - name: cloudzero-api-key
-              mountPath: {{ .Values.server.containerSecretFilePath }}
+              mountPath: {{ .Values.serverConfig.containerSecretFilePath }}
               subPath: ""
               readOnly: true
           {{- end }}

--- a/charts/cloudzero-agent/templates/deploy.yaml
+++ b/charts/cloudzero-agent/templates/deploy.yaml
@@ -174,9 +174,6 @@ spec:
             name: {{ template "cloudzero-agent.validatorConfigMapName" . }}
         - name: lifecycle-volume
           emptyDir: {}
-        {{- if or .Values.existingSecretName .Values.apiKey}}
-        {{- fail "The `existingSecretName` or `apiKey` setting should be set as `globals.existingSecretName` or `globals.apiKey`, not at the top level." }}
-        {{- end }}
         {{- if or .Values.existingSecretName .Values.apiKey }}
         - name: cloudzero-api-key
           secret:

--- a/charts/cloudzero-agent/templates/deploy.yaml
+++ b/charts/cloudzero-agent/templates/deploy.yaml
@@ -29,7 +29,7 @@ spec:
 {{- if .Values.server.priorityClassName }}
       priorityClassName: "{{ .Values.server.priorityClassName }}"
 {{- end }}
-      serviceAccountName: {{ template "cloudzero-agent.serviceAccountName.server" . }}
+      serviceAccountName: {{ template "cloudzero-agent.serviceAccountName" . }}
       initContainers:
         - name: {{ .Values.validator.name }}
           image: "{{ .Values.validator.image.repository }}:{{ .Values.validator.image.tag }}"
@@ -132,7 +132,7 @@ spec:
               mountPath: /check/
             - name: validator-config-volume
               mountPath: /check/app/config/
-          {{- if or .Values.global.existingSecretName .Values.global.apiKey }}
+          {{- if or .Values.existingSecretName .Values.apiKey }}
             - name: cloudzero-api-key
               mountPath: {{ .Values.server.containerSecretFilePath }}
               subPath: ""
@@ -177,7 +177,7 @@ spec:
         {{- if or .Values.existingSecretName .Values.apiKey}}
         {{- fail "The `existingSecretName` or `apiKey` setting should be set as `globals.existingSecretName` or `globals.apiKey`, not at the top level." }}
         {{- end }}
-        {{- if or .Values.global.existingSecretName .Values.global.apiKey }}
+        {{- if or .Values.existingSecretName .Values.apiKey }}
         - name: cloudzero-api-key
           secret:
             secretName: {{ include "cloudzero-agent.secretName" . }}

--- a/charts/cloudzero-agent/templates/deploy.yaml
+++ b/charts/cloudzero-agent/templates/deploy.yaml
@@ -39,7 +39,7 @@ spec:
             - -c
             - cp -r /app /checks/bin/ && cloudzero-agent-validator d pre-start -f /checks/config/validator.yml
           volumeMounts:
-          {{- if or .Values.global.existingSecretName .Values.global.apiKey }}
+          {{- if or .Values.existingSecretName .Values.apiKey }}
             - name: cloudzero-api-key
               mountPath: {{ .Values.server.containerSecretFilePath }}
               subPath: ""

--- a/charts/cloudzero-agent/templates/init-job.yaml
+++ b/charts/cloudzero-agent/templates/init-job.yaml
@@ -2,18 +2,18 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ include "insights-controller.initJobName" . }}
+  name: {{ include "cloudzero-agent.initJobName" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "insights-controller.labels" . | nindent 4 }}
+    {{- include "cloudzero-agent.tags.labels" . | nindent 4 }}
 spec:
   template:
     metadata:
-      name: {{ include "insights-controller.initJobName" . }}
+      name: {{ include "cloudzero-agent.initJobName" . }}
       labels:
-        {{- include "insights-controller.labels" . | nindent 8 }}
+        {{- include "cloudzero-agent.tags.labels" . | nindent 8 }}
     spec:
-      serviceAccountName: {{ include "insights-controller.serviceAccountName" . }}
+      serviceAccountName: {{ include "cloudzero-agent.serviceAccountName" . }}
       restartPolicy: Never
       containers:
         - name: start-scrape
@@ -23,9 +23,9 @@ spec:
             - |
               while true; do
                 echo "Waiting for the tags server to be ready...";
-                if curl -s -o /dev/null -w "%{http_code}" -k https://{{ include "insights-controller.serviceName" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.server.service.port }}/healthz | grep -q 200; then
+                if curl -s -o /dev/null -w "%{http_code}" -k https://{{ include "cloudzero-agent.serviceName" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.tags.service.port }}/healthz | grep -q 200; then
                   echo "Server is ready, starting scrape job...";
-                  curl -X POST -k https://{{ include "insights-controller.serviceName" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.server.service.port }}/scrape;
+                  curl -X POST -k https://{{ include "cloudzero-agent.serviceName" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.tags.service.port }}/scrape;
                   echo "Scrape process started.";
                   break;
                 fi;

--- a/charts/cloudzero-agent/templates/init-job.yaml
+++ b/charts/cloudzero-agent/templates/init-job.yaml
@@ -11,7 +11,7 @@ spec:
     metadata:
       name: {{ include "cloudzero-agent.initJobName" . }}
       labels:
-        {{- include "cloudzero-agent.tags.labels" . | nindent 8 }}
+        {{- include "cloudzero-agent.tags.initJob.matchLabels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ include "cloudzero-agent.serviceAccountName" . }}
       restartPolicy: Never

--- a/charts/cloudzero-agent/templates/init-job.yaml
+++ b/charts/cloudzero-agent/templates/init-job.yaml
@@ -5,13 +5,13 @@ metadata:
   name: {{ include "cloudzero-agent.initJobName" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "cloudzero-agent.tags.labels" . | nindent 4 }}
+    {{- include "cloudzero-agent.insightsController.labels" . | nindent 4 }}
 spec:
   template:
     metadata:
       name: {{ include "cloudzero-agent.initJobName" . }}
       labels:
-        {{- include "cloudzero-agent.tags.initJob.matchLabels" . | nindent 8 }}
+        {{- include "cloudzero-agent.insightsController.initJob.matchLabels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ include "cloudzero-agent.serviceAccountName" . }}
       restartPolicy: Never
@@ -22,10 +22,10 @@ spec:
           args:
             - |
               while true; do
-                echo "Waiting for the tags server to be ready...";
-                if curl -s -o /dev/null -w "%{http_code}" -k https://{{ include "cloudzero-agent.serviceName" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.tags.service.port }}/healthz | grep -q 200; then
+                echo "Waiting for the insightsController server to be ready...";
+                if curl -s -o /dev/null -w "%{http_code}" -k https://{{ include "cloudzero-agent.serviceName" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.insightsController.service.port }}/healthz | grep -q 200; then
                   echo "Server is ready, starting scrape job...";
-                  curl -X POST -k https://{{ include "cloudzero-agent.serviceName" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.tags.service.port }}/scrape;
+                  curl -X POST -k https://{{ include "cloudzero-agent.serviceName" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.insightsController.service.port }}/scrape;
                   echo "Scrape process started.";
                   break;
                 fi;

--- a/charts/cloudzero-agent/templates/init-job.yaml
+++ b/charts/cloudzero-agent/templates/init-job.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.initJob.enabled }}
+{{- if and .Values.initJob.enabled .Values.insightsController.enabled }}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/charts/cloudzero-agent/templates/init-job.yaml
+++ b/charts/cloudzero-agent/templates/init-job.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.initJob.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "insights-controller.initJobName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "insights-controller.labels" . | nindent 4 }}
+spec:
+  template:
+    metadata:
+      name: {{ include "insights-controller.initJobName" . }}
+      labels:
+        {{- include "insights-controller.labels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "insights-controller.serviceAccountName" . }}
+      restartPolicy: Never
+      containers:
+        - name: start-scrape
+          image: {{ .Values.initJob.image.repository }}:{{ .Values.initJob.image.tag }}
+          command: ["sh", "-c"]
+          args:
+            - |
+              while true; do
+                echo "Waiting for the tags server to be ready...";
+                if curl -s -o /dev/null -w "%{http_code}" -k https://{{ include "insights-controller.serviceName" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.server.service.port }}/healthz | grep -q 200; then
+                  echo "Server is ready, starting scrape job...";
+                  curl -X POST -k https://{{ include "insights-controller.serviceName" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.server.service.port }}/scrape;
+                  echo "Scrape process started.";
+                  break;
+                fi;
+                echo "No 200 response from health endpoint. Retrying in 30 seconds...";
+                sleep 30;
+              done
+{{- end }}

--- a/charts/cloudzero-agent/templates/insights-deploy.yaml
+++ b/charts/cloudzero-agent/templates/insights-deploy.yaml
@@ -1,0 +1,101 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+{{- if .Values.tags.server.deploymentAnnotations }}
+  annotations:
+    {{- toYaml .Values.tags.server.deploymentAnnotations | nindent 4 }}
+{{- end }}
+  name: {{ include "cloudzero-agent.tags.server.webhookFullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "cloudzero-agent.tags.server.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.tags.server.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "cloudzero-agent.tags.server.matchLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.tags.server.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "cloudzero-agent.tags.server.labels" . | nindent 8 }}
+        {{- with .Values.tags.server.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "cloudzero-agent.serviceAccountName" . }}
+      {{- with .Values.tags.server.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        runAsUser: 65534
+        runAsNonRoot: true
+        runAsGroup: 65534
+        fsGroup: 65534
+      containers:
+        - name: webhook-server
+          image: "{{ .Values.tags.server.image.repository }}:{{ .Values.tags.server.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.tags.server.image.pullPolicy }}
+          command:
+            - /app/controller
+          args:
+            - -config
+            - "{{ include "cloudzero-agent.tags.configurationMountPath" . }}/server-config.yaml"
+          ports:
+            - containerPort: 8443
+          resources:
+            {{- toYaml .Values.tags.server.resources | nindent 12 }}
+          {{- if or .Values.tags.server.volumeMounts .Values.tags.server.tls.useManagedSecret }}
+          volumeMounts:
+            - name: insights-server-config
+              mountPath: {{ include "cloudzero-agent.tags.configurationMountPath" . }}
+            {{- if .Values.tags.server.tls.useManagedCertificate }}
+            - name: tls-certs
+              mountPath: {{ .Values.tags.server.tls.mountPath }}
+              readOnly: true
+            {{- end }}
+          {{- if or .Values.existingSecretName .Values.apiKey }}
+            - name: cloudzero-api-key
+              mountPath: {{ default .Values.tags.server.containerSecretFilePath .Values.tags.server.containerSecretFilePath }}
+              subPath: ""
+              readOnly: true
+          {{- end }}
+            {{- with .Values.tags.server.volumeMounts }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- end }}
+      {{- if or .Values.tags.server.volumes .Values.tags.server.tls.useManagedCertificate }}
+      volumes:
+        - name: insights-server-config
+          configMap:
+            name: {{ include "cloudzero-agent.configMapName" . }}
+        {{- if .Values.tags.server.tls.useManagedCertificate }}
+        - name: tls-certs
+          secret:
+            secretName: {{ include "cloudzero-agent.tlsSecretName" . }}
+        {{- end }}
+        {{- if or .Values.existingSecretName .Values.apiKey }}
+        - name: cloudzero-api-key
+          secret:
+            secretName: {{ include "cloudzero-agent.secretName" . }}
+        {{- end }}
+        {{- with .Values.tags.server.volumes }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
+      {{- with .Values.tags.server.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tags.server.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tags.server.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/cloudzero-agent/templates/insights-deploy.yaml
+++ b/charts/cloudzero-agent/templates/insights-deploy.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.insightsController.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -99,3 +100,4 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+{{- end }}

--- a/charts/cloudzero-agent/templates/insights-deploy.yaml
+++ b/charts/cloudzero-agent/templates/insights-deploy.yaml
@@ -49,10 +49,10 @@ spec:
             - containerPort: 8443
           resources:
             {{- toYaml .Values.tags.resources | nindent 12 }}
-          {{- if or .Values.tags.volumeMounts .Values.tags.server.tls.useManagedSecret }}
           volumeMounts:
             - name: insights-server-config
               mountPath: {{ include "cloudzero-agent.tags.configurationMountPath" . }}
+          {{- if or .Values.tags.volumeMounts .Values.tags.server.tls.useManagedCertificate }}
             {{- if .Values.tags.server.tls.useManagedCertificate }}
             - name: tls-certs
               mountPath: {{ .Values.tags.server.tls.mountPath }}
@@ -72,7 +72,7 @@ spec:
       volumes:
         - name: insights-server-config
           configMap:
-            name: {{ include "cloudzero-agent.configMapName" . }}
+            name: {{ include "cloudzero-agent.webhookConfigMapName" . }}
         {{- if .Values.tags.server.tls.useManagedCertificate }}
         - name: tls-certs
           secret:

--- a/charts/cloudzero-agent/templates/insights-deploy.yaml
+++ b/charts/cloudzero-agent/templates/insights-deploy.yaml
@@ -31,11 +31,12 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      securityContext:
-        runAsUser: 65534
-        runAsNonRoot: true
-        runAsGroup: 65534
-        fsGroup: 65534
+      securityContext: #FIXME
+        runAsUser: 0
+        allowPrivilegeEscalation: true
+        # runAsNonRoot: false
+        # runAsGroup: 65534
+        # fsGroup: 65534
       containers:
         - name: webhook-server
           image: "{{ .Values.tags.server.image.repository }}:{{ .Values.tags.server.image.tag | default .Chart.AppVersion }}"
@@ -60,7 +61,7 @@ spec:
             {{- end }}
           {{- if or .Values.existingSecretName .Values.apiKey }}
             - name: cloudzero-api-key
-              mountPath: {{ default .Values.tags.server.containerSecretFilePath .Values.tags.server.containerSecretFilePath }}
+              mountPath: {{ .Values.serverConfig.containerSecretFilePath }}
               subPath: ""
               readOnly: true
           {{- end }}

--- a/charts/cloudzero-agent/templates/insights-deploy.yaml
+++ b/charts/cloudzero-agent/templates/insights-deploy.yaml
@@ -1,62 +1,61 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-{{- if .Values.tags.server.deploymentAnnotations }}
+{{- if .Values.insightsController.server.deploymentAnnotations }}
   annotations:
-    {{- toYaml .Values.tags.server.deploymentAnnotations | nindent 4 }}
+    {{- toYaml .Values.insightsController.server.deploymentAnnotations | nindent 4 }}
 {{- end }}
-  name: {{ include "cloudzero-agent.tags.server.webhookFullname" . }}
+  name: {{ include "cloudzero-agent.insightsController.server.webhookFullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "cloudzero-agent.tags.labels" . | nindent 4 }}
+    {{- include "cloudzero-agent.insightsController.labels" . | nindent 4 }}
 spec:
-  replicas: {{ .Values.tags.server.replicaCount }}
+  replicas: {{ .Values.insightsController.server.replicaCount }}
   selector:
     matchLabels:
-      {{- include "cloudzero-agent.tags.server.matchLabels" . | nindent 6 }}
+      {{- include "cloudzero-agent.insightsController.server.matchLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.tags.server.podAnnotations }}
+      {{- with .Values.insightsController.server.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        {{- include "cloudzero-agent.tags.labels" . | nindent 8 }}
-        {{- with .Values.tags.server.podLabels }}
+        {{- include "cloudzero-agent.insightsController.labels" . | nindent 8 }}
+        {{- with .Values.insightsController.server.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
       serviceAccountName: {{ include "cloudzero-agent.serviceAccountName" . }}
-      {{- with .Values.tags.server.imagePullSecrets }}
+      {{- with .Values.insightsController.server.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      securityContext: #FIXME
-        runAsUser: 0
-        allowPrivilegeEscalation: true
-        # runAsNonRoot: false
-        # runAsGroup: 65534
-        # fsGroup: 65534
+      securityContext:
+        runAsUser: 65534
+        runAsNonRoot: true
+        runAsGroup: 65534
+        fsGroup: 65534
       containers:
         - name: webhook-server
-          image: "{{ .Values.tags.server.image.repository }}:{{ .Values.tags.server.image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: {{ .Values.tags.server.image.pullPolicy }}
+          image: "{{ .Values.insightsController.server.image.repository }}:{{ .Values.insightsController.server.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.insightsController.server.image.pullPolicy }}
           command:
             - /app/controller
           args:
             - -config
-            - "{{ include "cloudzero-agent.tags.configurationMountPath" . }}/server-config.yaml"
+            - "{{ include "cloudzero-agent.insightsController.configurationMountPath" . }}/server-config.yaml"
           ports:
             - containerPort: 8443
           resources:
-            {{- toYaml .Values.tags.resources | nindent 12 }}
+            {{- toYaml .Values.insightsController.resources | nindent 12 }}
           volumeMounts:
             - name: insights-server-config
-              mountPath: {{ include "cloudzero-agent.tags.configurationMountPath" . }}
-          {{- if or .Values.tags.volumeMounts .Values.tags.server.tls.useManagedCertificate }}
-            {{- if .Values.tags.server.tls.useManagedCertificate }}
+              mountPath: {{ include "cloudzero-agent.insightsController.configurationMountPath" . }}
+          {{- if or .Values.insightsController.volumeMounts .Values.insightsController.server.tls.useManagedCertificate }}
+            {{- if .Values.insightsController.server.tls.useManagedCertificate }}
             - name: tls-certs
-              mountPath: {{ .Values.tags.server.tls.mountPath }}
+              mountPath: {{ .Values.insightsController.server.tls.mountPath }}
               readOnly: true
             {{- end }}
           {{- if or .Values.existingSecretName .Values.apiKey }}
@@ -65,16 +64,16 @@ spec:
               subPath: ""
               readOnly: true
           {{- end }}
-            {{- with .Values.tags.volumeMounts }}
+            {{- with .Values.insightsController.volumeMounts }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
           {{- end }}
-      {{- if or .Values.tags.volumes .Values.tags.server.tls.useManagedCertificate }}
+      {{- if or .Values.insightsController.volumes .Values.insightsController.server.tls.useManagedCertificate }}
       volumes:
         - name: insights-server-config
           configMap:
             name: {{ include "cloudzero-agent.webhookConfigMapName" . }}
-        {{- if .Values.tags.server.tls.useManagedCertificate }}
+        {{- if .Values.insightsController.server.tls.useManagedCertificate }}
         - name: tls-certs
           secret:
             secretName: {{ include "cloudzero-agent.tlsSecretName" . }}
@@ -84,19 +83,19 @@ spec:
           secret:
             secretName: {{ include "cloudzero-agent.secretName" . }}
         {{- end }}
-        {{- with .Values.tags.volumes }}
+        {{- with .Values.insightsController.volumes }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- end }}
-      {{- with .Values.tags.server.nodeSelector }}
+      {{- with .Values.insightsController.server.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.tags.server.affinity }}
+      {{- with .Values.insightsController.server.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.tags.server.tolerations }}
+      {{- with .Values.insightsController.server.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/cloudzero-agent/templates/insights-deploy.yaml
+++ b/charts/cloudzero-agent/templates/insights-deploy.yaml
@@ -48,8 +48,8 @@ spec:
           ports:
             - containerPort: 8443
           resources:
-            {{- toYaml .Values.tags.server.resources | nindent 12 }}
-          {{- if or .Values.tags.server.volumeMounts .Values.tags.server.tls.useManagedSecret }}
+            {{- toYaml .Values.tags.resources | nindent 12 }}
+          {{- if or .Values.tags.volumeMounts .Values.tags.server.tls.useManagedSecret }}
           volumeMounts:
             - name: insights-server-config
               mountPath: {{ include "cloudzero-agent.tags.configurationMountPath" . }}
@@ -64,11 +64,11 @@ spec:
               subPath: ""
               readOnly: true
           {{- end }}
-            {{- with .Values.tags.server.volumeMounts }}
+            {{- with .Values.tags.volumeMounts }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
           {{- end }}
-      {{- if or .Values.tags.server.volumes .Values.tags.server.tls.useManagedCertificate }}
+      {{- if or .Values.tags.volumes .Values.tags.server.tls.useManagedCertificate }}
       volumes:
         - name: insights-server-config
           configMap:
@@ -83,7 +83,7 @@ spec:
           secret:
             secretName: {{ include "cloudzero-agent.secretName" . }}
         {{- end }}
-        {{- with .Values.tags.server.volumes }}
+        {{- with .Values.tags.volumes }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- end }}

--- a/charts/cloudzero-agent/templates/insights-deploy.yaml
+++ b/charts/cloudzero-agent/templates/insights-deploy.yaml
@@ -8,7 +8,7 @@ metadata:
   name: {{ include "cloudzero-agent.tags.server.webhookFullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "cloudzero-agent.tags.server.labels" . | nindent 4 }}
+    {{- include "cloudzero-agent.tags.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.tags.server.replicaCount }}
   selector:
@@ -21,7 +21,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        {{- include "cloudzero-agent.tags.server.labels" . | nindent 8 }}
+        {{- include "cloudzero-agent.tags.labels" . | nindent 8 }}
         {{- with .Values.tags.server.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/cloudzero-agent/templates/issuer.yaml
+++ b/charts/cloudzero-agent/templates/issuer.yaml
@@ -1,5 +1,4 @@
-{{ if .Values.insightsController.enabled }}
-{{ if and .Values.insightsController.webhooks.issuer.enabled (.Values.certManager.enabled) }}
+{{ if and .Values.insightsController.webhooks.issuer.enabled .Values.insightsController.enabled }}
 ---
 apiVersion: cert-manager.io/v1
 kind: Issuer
@@ -8,5 +7,4 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   {{- toYaml .Values.insightsController.webhooks.issuer.spec | nindent 2 }}
-{{- end }}
 {{- end }}

--- a/charts/cloudzero-agent/templates/issuer.yaml
+++ b/charts/cloudzero-agent/templates/issuer.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.tags.webhooks.issuer.enabled }}
+{{ if .Values.insightsController.webhooks.issuer.enabled }}
 ---
 apiVersion: cert-manager.io/v1
 kind: Issuer
@@ -6,5 +6,5 @@ metadata:
   name: {{ include "cloudzero-agent.issuerName" . }}
   namespace: {{ .Release.Namespace }}
 spec:
-  {{- toYaml .Values.tags.webhooks.issuer.spec | nindent 2 }}
+  {{- toYaml .Values.insightsController.webhooks.issuer.spec | nindent 2 }}
 {{- end }}

--- a/charts/cloudzero-agent/templates/issuer.yaml
+++ b/charts/cloudzero-agent/templates/issuer.yaml
@@ -1,10 +1,10 @@
-{{ if .Values.webhook.issuer.enabled }}
+{{ if .Values.tags.webhooks.issuer.enabled }}
 ---
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
-  name: {{ include "insights-controller.issuerName" . }}
+  name: {{ include "cloudzero-agent.issuerName" . }}
   namespace: {{ .Release.Namespace }}
 spec:
-  {{- toYaml .Values.webhook.issuer.spec | nindent 2 }}
+  {{- toYaml .Values.tags.webhooks.issuer.spec | nindent 2 }}
 {{- end }}

--- a/charts/cloudzero-agent/templates/issuer.yaml
+++ b/charts/cloudzero-agent/templates/issuer.yaml
@@ -1,0 +1,10 @@
+{{ if .Values.webhook.issuer.enabled }}
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ include "insights-controller.issuerName" . }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  {{- toYaml .Values.webhook.issuer.spec | nindent 2 }}
+{{- end }}

--- a/charts/cloudzero-agent/templates/issuer.yaml
+++ b/charts/cloudzero-agent/templates/issuer.yaml
@@ -1,4 +1,5 @@
-{{ if .Values.insightsController.webhooks.issuer.enabled }}
+{{ if .Values.insightsController.enabled }}
+{{ if and .Values.insightsController.webhooks.issuer.enabled (.Values.certManager.enabled) }}
 ---
 apiVersion: cert-manager.io/v1
 kind: Issuer
@@ -7,4 +8,5 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   {{- toYaml .Values.insightsController.webhooks.issuer.spec | nindent 2 }}
+{{- end }}
 {{- end }}

--- a/charts/cloudzero-agent/templates/secret.yaml
+++ b/charts/cloudzero-agent/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.global.apiKey }}
+{{- if .Values.apiKey }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -11,7 +11,7 @@ metadata:
   {{- toYaml . | nindent 4 }}
   {{- end }}
 data:
-  {{ .Values.server.containerSecretFileName }}: {{- $apiKey := .Values.global.apiKey | toString }}
+  {{ .Values.server.containerSecretFileName }}: {{- $apiKey := .Values.apiKey | toString }}
           {{- if not (regexMatch "^[a-zA-Z0-9-_.~!*'();]+$" $apiKey) }}
           {{- fail "The provided apiKey is invalid. Check that the provided value from apiKey matches exactly what is found in the CloudZero admin page." }}
           {{- end }}

--- a/charts/cloudzero-agent/templates/secret.yaml
+++ b/charts/cloudzero-agent/templates/secret.yaml
@@ -11,7 +11,7 @@ metadata:
   {{- toYaml . | nindent 4 }}
   {{- end }}
 data:
-  {{ .Values.server.containerSecretFileName }}: {{- $apiKey := .Values.apiKey | toString }}
+  {{ .Values.serverConfig.containerSecretFileName }}: {{- $apiKey := .Values.apiKey | toString }}
           {{- if not (regexMatch "^[a-zA-Z0-9-_.~!*'();]+$" $apiKey) }}
           {{- fail "The provided apiKey is invalid. Check that the provided value from apiKey matches exactly what is found in the CloudZero admin page." }}
           {{- end }}

--- a/charts/cloudzero-agent/templates/service.yaml
+++ b/charts/cloudzero-agent/templates/service.yaml
@@ -3,13 +3,13 @@ kind: Service
 metadata:
   name: {{ include "cloudzero-agent.serviceName" . }}
   labels:
-    {{- include "cloudzero-agent.tags.labels" . | nindent 4 }}
+    {{- include "cloudzero-agent.insightsController.labels" . | nindent 4 }}
   namespace: {{ .Release.Namespace }}
 spec:
   type: ClusterIP
   ports:
-    - port: {{ .Values.tags.service.port }}
+    - port: {{ .Values.insightsController.service.port }}
       targetPort: 8443
       name: http
   selector:
-    {{- include "cloudzero-agent.tags.server.matchLabels" . | nindent 4 }}
+    {{- include "cloudzero-agent.insightsController.server.matchLabels" . | nindent 4 }}

--- a/charts/cloudzero-agent/templates/service.yaml
+++ b/charts/cloudzero-agent/templates/service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   name: {{ include "cloudzero-agent.serviceName" . }}
   labels:
-    {{- include "cloudzero-agent.tags.server.labels" . | nindent 4 }}
+    {{- include "cloudzero-agent.tags.labels" . | nindent 4 }}
   namespace: {{ .Release.Namespace }}
 spec:
   type: ClusterIP

--- a/charts/cloudzero-agent/templates/service.yaml
+++ b/charts/cloudzero-agent/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "cloudzero-agent.serviceName" . }}
+  labels:
+    {{- include "cloudzero-agent.tags.server.labels" . | nindent 4 }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.tags.service.port }}
+      targetPort: 8443
+      name: http
+  selector:
+    {{- include "cloudzero-agent.tags.server.matchLabels" . | nindent 4 }}

--- a/charts/cloudzero-agent/templates/serviceaccount.yaml
+++ b/charts/cloudzero-agent/templates/serviceaccount.yaml
@@ -1,17 +1,17 @@
-{{- if .Values.serviceAccounts.server.create }}
+{{- if .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
     {{- include "cloudzero-agent.server.labels" . | nindent 4 }}
-  name: {{ template "cloudzero-agent.serviceAccountName.server" . }}
+  name: {{ template "cloudzero-agent.serviceAccountName" . }}
   namespace: {{ include "cloudzero-agent.namespace" . }}
   annotations:
-{{ toYaml .Values.serviceAccounts.server.annotations | indent 4 }}
+{{ toYaml .Values.serviceAccount.annotations | indent 4 }}
 {{- if kindIs "bool" .Values.server.automountServiceAccountToken }}
 automountServiceAccountToken: {{ .Values.server.automountServiceAccountToken }}
-{{- else if kindIs "bool" .Values.serviceAccounts.server.automountServiceAccountToken }}
-automountServiceAccountToken: {{ .Values.serviceAccounts.server.automountServiceAccountToken }}
+{{- else if kindIs "bool" .Values.serviceAccount.automountServiceAccountToken }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 {{- end }}
 {{- end }}
 

--- a/charts/cloudzero-agent/templates/webhooks.yaml
+++ b/charts/cloudzero-agent/templates/webhooks.yaml
@@ -9,7 +9,7 @@ metadata:
     {{- include "cloudzero-agent.tags.labels" $ | nindent 4 }}
   {{- if .annotations}}
   annotations:
-    {{- toYaml .annotations | nindent 4 }}
+    {{- include "cloudzero-agent.webhooks.annotations" $ | nindent 4 }}
   {{- end }}
 webhooks:
   - name: {{ include "cloudzero-agent.validatingWebhookName" $ }}

--- a/charts/cloudzero-agent/templates/webhooks.yaml
+++ b/charts/cloudzero-agent/templates/webhooks.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.insightsController.enabled }}
 {{- range $configType, $configs := .Values.insightsController.webhooks.configurations }}
 {{- if or (index $.Values.insightsController.labels.resources $configType) (index $.Values.insightsController.annotations.resources $configType) }}
 ---
@@ -32,5 +33,6 @@ webhooks:
     admissionReviewVersions: ["v1"]
     sideEffects: None
     timeoutSeconds: 5
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/cloudzero-agent/templates/webhooks.yaml
+++ b/charts/cloudzero-agent/templates/webhooks.yaml
@@ -1,0 +1,36 @@
+{{- range $configType, $configs := .Values.tags.webhook.configurations }}
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: {{ include "cloudzero-agent.validatingWebhookConfigName" $ }}-{{ $configType }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- include "cloudzero-agent.tags.server.labels" $ | nindent 4 }}
+  {{- if .annotations}}
+  annotations:
+    {{- toYaml .annotations | nindent 4 }}
+  {{- end }}
+webhooks:
+  - name: {{ include "cloudzero-agent.validatingWebhookName" $ }}
+    namespaceSelector: {{ toYaml $.Values.tags.webhooks.namespaceSelector }}
+    failurePolicy: Ignore
+    rules:
+      - operations: [ "CREATE", "UPDATE" ]
+        apiGroups: {{ $configs.apiGroups }}
+        apiVersions: [ "v1" ]
+        resources: [ {{ $configType }} ]
+        scope: "*"
+    clientConfig:
+      service:
+        namespace: {{ $.Release.Namespace }}
+        name: {{ include "cloudzero-agent.serviceName" $ }}
+        path: "{{ $configs.path }}"
+        port: {{ $.Values.tags.service.port }}
+      {{- if and $.Values.tags.webhooks.certificate.enabled $.Values.tags.webhooks.issuer.enabled }}
+      caBundle: {{ $.Values.tags.webhooks.caBundle }}
+      {{- end }}
+    admissionReviewVersions: ["v1"]
+    sideEffects: None
+    timeoutSeconds: 5
+{{- end }}

--- a/charts/cloudzero-agent/templates/webhooks.yaml
+++ b/charts/cloudzero-agent/templates/webhooks.yaml
@@ -1,4 +1,4 @@
-{{- range $configType, $configs := .Values.tags.webhook.configurations }}
+{{- range $configType, $configs := .Values.insightsController.webhooks.configurations }}
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
@@ -6,14 +6,14 @@ metadata:
   name: {{ include "cloudzero-agent.validatingWebhookConfigName" $ }}-{{ $configType }}
   namespace: {{ $.Release.Namespace }}
   labels:
-    {{- include "cloudzero-agent.tags.labels" $ | nindent 4 }}
+    {{- include "cloudzero-agent.insightsController.labels" $ | nindent 4 }}
   {{- if .annotations}}
   annotations:
     {{- include "cloudzero-agent.webhooks.annotations" $ | nindent 4 }}
   {{- end }}
 webhooks:
   - name: {{ include "cloudzero-agent.validatingWebhookName" $ }}
-    namespaceSelector: {{ toYaml $.Values.tags.webhooks.namespaceSelector }}
+    namespaceSelector: {{ toYaml $.Values.insightsController.webhooks.namespaceSelector }}
     failurePolicy: Ignore
     rules:
       - operations: [ "CREATE", "UPDATE" ]
@@ -26,9 +26,9 @@ webhooks:
         namespace: {{ $.Release.Namespace }}
         name: {{ include "cloudzero-agent.serviceName" $ }}
         path: "{{ $configs.path }}"
-        port: {{ $.Values.tags.service.port }}
-      {{- if and $.Values.tags.webhooks.certificate.enabled $.Values.tags.webhooks.issuer.enabled }}
-      caBundle: {{ $.Values.tags.webhooks.caBundle }}
+        port: {{ $.Values.insightsController.service.port }}
+      {{- if and $.Values.insightsController.webhooks.certificate.enabled $.Values.insightsController.webhooks.issuer.enabled }}
+      caBundle: {{ $.Values.insightsController.webhooks.caBundle }}
       {{- end }}
     admissionReviewVersions: ["v1"]
     sideEffects: None

--- a/charts/cloudzero-agent/templates/webhooks.yaml
+++ b/charts/cloudzero-agent/templates/webhooks.yaml
@@ -1,4 +1,5 @@
 {{- range $configType, $configs := .Values.insightsController.webhooks.configurations }}
+{{- if or (index $.Values.insightsController.labels.resources $configType) (index $.Values.insightsController.annotations.resources $configType) }}
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
@@ -7,10 +8,8 @@ metadata:
   namespace: {{ $.Release.Namespace }}
   labels:
     {{- include "cloudzero-agent.insightsController.labels" $ | nindent 4 }}
-  {{- if .annotations}}
   annotations:
     {{- include "cloudzero-agent.webhooks.annotations" $ | nindent 4 }}
-  {{- end }}
 webhooks:
   - name: {{ include "cloudzero-agent.validatingWebhookName" $ }}
     namespaceSelector: {{ toYaml $.Values.insightsController.webhooks.namespaceSelector }}
@@ -33,4 +32,5 @@ webhooks:
     admissionReviewVersions: ["v1"]
     sideEffects: None
     timeoutSeconds: 5
+{{- end }}
 {{- end }}

--- a/charts/cloudzero-agent/templates/webhooks.yaml
+++ b/charts/cloudzero-agent/templates/webhooks.yaml
@@ -6,7 +6,7 @@ metadata:
   name: {{ include "cloudzero-agent.validatingWebhookConfigName" $ }}-{{ $configType }}
   namespace: {{ $.Release.Namespace }}
   labels:
-    {{- include "cloudzero-agent.tags.server.labels" $ | nindent 4 }}
+    {{- include "cloudzero-agent.tags.labels" $ | nindent 4 }}
   {{- if .annotations}}
   annotations:
     {{- toYaml .annotations | nindent 4 }}

--- a/charts/cloudzero-agent/values.yaml
+++ b/charts/cloudzero-agent/values.yaml
@@ -7,11 +7,10 @@ clusterName: null
 # -- Region the cluster is running in.
 region: null
 
-global:
-  # -- CloudZero API key. Required if useExistingSecret is false.
-  apiKey: null
-  # -- If set, the agent will use the API key in this Secret to authenticate with CloudZero.
-  existingSecretName: null
+# -- CloudZero API key. Required if useExistingSecret is false.
+apiKey: null
+# -- If set, the agent will use the API key in this Secret to authenticate with CloudZero.
+existingSecretName: null
 
 # -- The following lists of metrics are required for CloudZero to function.
 # -- Modifications made to these lists may cause issues with the processing of cluster data
@@ -123,6 +122,13 @@ tags:
         path: /validate/daemonset
         apiGroups: [ "apps" ]
 
+# General server settings that apply to both the prometheus agent server and the webhook server
+serverConfig:
+  # -- The agent will use this file path on the container filesystem to get the CZ API key.
+  containerSecretFilePath: /etc/config/secrets/
+  # -- The agent will look for a file with this name to get the CZ API key.
+  containerSecretFileName: value
+
 initJob:
   enabled: true
   image:
@@ -182,10 +188,6 @@ server:
   - --web.console.libraries=/etc/prometheus/console_libraries
   - --web.console.templates=/etc/prometheus/consoles
   - --enable-feature=agent
-  # -- The agent will use this file path on the container filesystem to get the CZ API key.
-  containerSecretFilePath: /etc/config/prometheus/secrets/
-  # -- The agent will look for a file with this name to get the CZ API key.
-  containerSecretFileName: value
   persistentVolume:
     existingClaim: ""
     enabled: false

--- a/charts/cloudzero-agent/values.yaml
+++ b/charts/cloudzero-agent/values.yaml
@@ -48,6 +48,7 @@ prometheusConfig:
     # -- Any items added to this list will be added to the Prometheus scrape configuration.
     additionalScrapeJobs: []
 
+# webhook
 tags:
   enabled: true
   labels:
@@ -58,6 +59,34 @@ tags:
     enabled: false
     patterns:
       - '.*'
+  server:
+    name: tags-webhook
+    replicaCount: 3
+    image:
+      repository: ghcr.io/cloudzero/cloudzero-insights-controller/cloudzero-insights-controller
+      tag: 0.0.2
+      pullPolicy: Always
+    tls:
+      enabled: true
+      useManagedCertificate: true
+      mountPath: /etc/certs
+    containerSecretFilePath: /etc/config/cloudzero/secrets
+    containerSecretFileName: value
+    port: 8443
+    read_timeout: 10s
+    write_timeout: 10s
+    idle_timeout: 120s
+    volumeMounts: []
+    volumes: []
+  resources: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  imagePullSecrets: []
+  podAnnotations: {}
+  podLabels: {}
+
+
 
 kubeStateMetrics:
   enabled: true
@@ -128,11 +157,10 @@ server:
   emptyDir:
     sizeLimit: 8Gi
 
-serviceAccounts:
-  server:
-    create: true
-    name: ""
-    annotations: {}
+serviceAccount:
+  create: true
+  name: ""
+  annotations: {}
 
 rbac:
   create: true

--- a/charts/cloudzero-agent/values.yaml
+++ b/charts/cloudzero-agent/values.yaml
@@ -164,41 +164,39 @@ insightsController:
     port: 443
   webhooks:
     annotations: {}
-    namespaceSelector: {} # This denotes no specific selection, applies to all namespaces
+    namespaceSelector: {}  # This denotes no specific selection, applies to all namespaces
     issuer:
       enabled: true
       spec:
         selfSigned: {}
     certificate:
       enabled: true
-    caBundle: '' # by default, this is empty, and the value is populated by cert-manager's ca-injector if cert-manager is used
+    caBundle: ''  # by default, this is empty, and the value is populated by cert-manager's ca-injector if cert-manager is used
     configurations:
       pods:
         path: /validate/pod
-        apiGroups: [ '""' ]
+        apiGroups: ['""']
       namespaces:
         path: /validate/namespace
-        apiGroups: [ '""' ]
+        apiGroups: ['""']
       deployments:
         path: /validate/deployment
-        apiGroups: [ "apps" ]
+        apiGroups: ["apps"]
       statefulsets:
         path: /validate/statefulset
-        apiGroups: [ "apps" ]
+        apiGroups: ["apps"]
       nodes:
         path: /validate/node
-        apiGroups: [ '""' ]
+        apiGroups: ['""']
       jobs:
         path: /validate/job
-        apiGroups: [ "batch" ]
+        apiGroups: ["batch"]
       cronjobs:
         path: /validate/cronjob
-        apiGroups: [ "batch" ]
+        apiGroups: ["batch"]
       daemonsets:
         path: /validate/daemonset
-        apiGroups: [ "apps" ]
-
-
+        apiGroups: ["apps"]
 
 serviceAccount:
   create: true

--- a/charts/cloudzero-agent/values.yaml
+++ b/charts/cloudzero-agent/values.yaml
@@ -47,81 +47,6 @@ prometheusConfig:
     # -- Any items added to this list will be added to the Prometheus scrape configuration.
     additionalScrapeJobs: []
 
-# todo change to insightsWebhook
-tags:
-  enabled: true
-  labels:
-    enabled:
-    patterns:
-      # - '.*'
-  annotations:
-    enabled: false
-    patterns:
-      - '.*'
-  server:
-    name: tags-webhook
-    replicaCount: 3
-    image:
-      repository: ghcr.io/cloudzero/cloudzero-insights-controller/cloudzero-insights-controller
-      tag: 0.0.2
-      pullPolicy: Always
-    tls:
-      enabled: true
-      useManagedCertificate: true
-      mountPath: /etc/certs
-    containerSecretFilePath: /etc/config/cloudzero/secrets
-    containerSecretFileName: value
-    port: 8443
-    read_timeout: 10s
-    write_timeout: 10s
-    idle_timeout: 120s
-  volumeMounts: []
-  volumes: []
-  resources: {}
-  nodeSelector: {}
-  tolerations: []
-  affinity: {}
-  imagePullSecrets: []
-  podAnnotations: {}
-  podLabels: {}
-  service:
-    port: 443
-  webhooks:
-    annotations: {}
-    namespaceSelector: {} # This denotes no specific selection, applies to all namespaces
-    issuer:
-      enabled: true
-      spec:
-        selfSigned: {}
-    certificate:
-      enabled: true
-    caBundle: '' # by default, this is empty, and the value is populated by cert-manager's ca-injector if cert-manager is used
-    configurations:
-      pods:
-        path: /validate/pod
-        apiGroups: [ '""' ]
-      namespaces:
-        path: /validate/namespace
-        apiGroups: [ '""' ]
-      deployments:
-        path: /validate/deployment
-        apiGroups: [ "apps" ]
-      statefulsets:
-        path: /validate/statefulset
-        apiGroups: [ "apps" ]
-      nodes:
-        path: /validate/node
-        apiGroups: [ '""' ]
-      jobs:
-        path: /validate/job
-        apiGroups: [ "batch" ]
-      cronjobs:
-        path: /validate/cronjob
-        apiGroups: [ "batch" ]
-      daemonsets:
-        path: /validate/daemonset
-        apiGroups: [ "apps" ]
-
 # General server settings that apply to both the prometheus agent server and the webhook server
 serverConfig:
   # -- The agent will use this file path on the container filesystem to get the CZ API key.
@@ -201,10 +126,88 @@ server:
   emptyDir:
     sizeLimit: 8Gi
 
+# todo change to insightsWebhook insightsController
+insightsController:
+  enabled: true
+  labels:
+    enabled:
+    patterns:
+      # - '.*'
+  annotations:
+    enabled: false
+    patterns:
+      - '.*'
+  server:
+    name: webhook-server
+    replicaCount: 3
+    image:
+      repository: ghcr.io/cloudzero/cloudzero-insights-controller/cloudzero-insights-controller
+      tag: 0.0.2
+      pullPolicy: Always
+    tls:
+      enabled: true
+      useManagedCertificate: true
+      mountPath: /etc/certs
+    port: 8443
+    read_timeout: 10s
+    write_timeout: 10s
+    idle_timeout: 120s
+  volumeMounts: []
+  volumes: []
+  resources: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  imagePullSecrets: []
+  podAnnotations: {}
+  podLabels: {}
+  service:
+    port: 443
+  webhooks:
+    annotations: {}
+    namespaceSelector: {} # This denotes no specific selection, applies to all namespaces
+    issuer:
+      enabled: true
+      spec:
+        selfSigned: {}
+    certificate:
+      enabled: true
+    caBundle: '' # by default, this is empty, and the value is populated by cert-manager's ca-injector if cert-manager is used
+    configurations:
+      pods:
+        path: /validate/pod
+        apiGroups: [ '""' ]
+      namespaces:
+        path: /validate/namespace
+        apiGroups: [ '""' ]
+      deployments:
+        path: /validate/deployment
+        apiGroups: [ "apps" ]
+      statefulsets:
+        path: /validate/statefulset
+        apiGroups: [ "apps" ]
+      nodes:
+        path: /validate/node
+        apiGroups: [ '""' ]
+      jobs:
+        path: /validate/job
+        apiGroups: [ "batch" ]
+      cronjobs:
+        path: /validate/cronjob
+        apiGroups: [ "batch" ]
+      daemonsets:
+        path: /validate/daemonset
+        apiGroups: [ "apps" ]
+
+
+
 serviceAccount:
   create: true
   name: ""
   annotations: {}
+
+cert-manager:
+  enabled: true
 
 rbac:
   create: true

--- a/charts/cloudzero-agent/values.yaml
+++ b/charts/cloudzero-agent/values.yaml
@@ -132,10 +132,28 @@ insightsController:
     enabled:
     patterns:
       # - '.*'
+    resources:
+      pods: true
+      namespaces: true
+      deployments: false
+      statefulsets: false
+      nodes: false
+      jobs: false
+      cronjobs: false
+      daemonsets: false
   annotations:
     enabled: false
     patterns:
       - '.*'
+    resources:
+      pods: true
+      namespaces: true
+      deployments: false
+      statefulsets: false
+      nodes: false
+      jobs: false
+      cronjobs: false
+      daemonsets: false
   server:
     name: webhook-server
     replicaCount: 3

--- a/charts/cloudzero-agent/values.yaml
+++ b/charts/cloudzero-agent/values.yaml
@@ -48,7 +48,7 @@ prometheusConfig:
     # -- Any items added to this list will be added to the Prometheus scrape configuration.
     additionalScrapeJobs: []
 
-# webhook
+# todo change to insightsWebhook
 tags:
   enabled: true
   labels:
@@ -85,6 +85,45 @@ tags:
   imagePullSecrets: []
   podAnnotations: {}
   podLabels: {}
+  service:
+    port: 443
+  webhooks:
+    annotations: {}
+    namespaceSelector: {} # This denotes no specific selection, applies to all namespaces
+    issuer:
+      enabled: true
+      spec:
+        selfSigned: {}
+    certificate:
+      enabled: true
+    caBundle: '' # by default, this is empty, and the value is populated by cert-manager's ca-injector if cert-manager is used
+    configurations:
+      pods:
+        path: /validate/pod
+        apiGroups: [ '""' ]
+      namespaces:
+        path: /validate/namespace
+        apiGroups: [ '""' ]
+      deployments:
+        path: /validate/deployment
+        apiGroups: [ "apps" ]
+      statefulsets:
+        path: /validate/statefulset
+        apiGroups: [ "apps" ]
+      nodes:
+        path: /validate/node
+        apiGroups: [ '""' ]
+      jobs:
+        path: /validate/job
+        apiGroups: [ "batch" ]
+      cronjobs:
+        path: /validate/cronjob
+        apiGroups: [ "batch" ]
+      daemonsets:
+        path: /validate/daemonset
+        apiGroups: [ "apps" ]
+
+
 
 
 

--- a/charts/cloudzero-agent/values.yaml
+++ b/charts/cloudzero-agent/values.yaml
@@ -123,9 +123,12 @@ tags:
         path: /validate/daemonset
         apiGroups: [ "apps" ]
 
-
-
-
+initJob:
+  enabled: true
+  image:
+    repository: curlimages/curl
+    pullPolicy: Always
+    tag: "8.10.1"
 
 kubeStateMetrics:
   enabled: true

--- a/charts/cloudzero-agent/values.yaml
+++ b/charts/cloudzero-agent/values.yaml
@@ -76,8 +76,8 @@ tags:
     read_timeout: 10s
     write_timeout: 10s
     idle_timeout: 120s
-    volumeMounts: []
-    volumes: []
+  volumeMounts: []
+  volumes: []
   resources: {}
   nodeSelector: {}
   tolerations: []

--- a/charts/cloudzero-agent/values.yaml
+++ b/charts/cloudzero-agent/values.yaml
@@ -221,7 +221,8 @@ serviceAccount:
   name: ""
   annotations: {}
 
-cert-manager:
+certManager:
+  fullnameOverride: "cert-manager"
   enabled: true
 
 rbac:

--- a/charts/cloudzero-agent/values.yaml
+++ b/charts/cloudzero-agent/values.yaml
@@ -126,7 +126,6 @@ server:
   emptyDir:
     sizeLimit: 8Gi
 
-# todo change to insightsWebhook insightsController
 insightsController:
   enabled: true
   labels:

--- a/charts/cloudzero-agent/values.yaml
+++ b/charts/cloudzero-agent/values.yaml
@@ -221,8 +221,7 @@ serviceAccount:
   name: ""
   annotations: {}
 
-certManager:
-  fullnameOverride: "cert-manager"
+cert-manager:
   enabled: true
 
 rbac:

--- a/charts/cloudzero-insights-controller/templates/init-job.yaml
+++ b/charts/cloudzero-insights-controller/templates/init-job.yaml
@@ -22,7 +22,7 @@ spec:
           args:
             - |
               while true; do
-                echo "Waiting for the insightsController server to be ready...";
+                echo "Waiting for the tags server to be ready...";
                 if curl -s -o /dev/null -w "%{http_code}" -k https://{{ include "insights-controller.serviceName" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.server.service.port }}/healthz | grep -q 200; then
                   echo "Server is ready, starting scrape job...";
                   curl -X POST -k https://{{ include "insights-controller.serviceName" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.server.service.port }}/scrape;

--- a/charts/cloudzero-insights-controller/templates/init-job.yaml
+++ b/charts/cloudzero-insights-controller/templates/init-job.yaml
@@ -22,7 +22,7 @@ spec:
           args:
             - |
               while true; do
-                echo "Waiting for the tags server to be ready...";
+                echo "Waiting for the insightsController server to be ready...";
                 if curl -s -o /dev/null -w "%{http_code}" -k https://{{ include "insights-controller.serviceName" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.server.service.port }}/healthz | grep -q 200; then
                   echo "Server is ready, starting scrape job...";
                   curl -X POST -k https://{{ include "insights-controller.serviceName" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.server.service.port }}/scrape;

--- a/charts/cloudzero-insights-controller/templates/init-job.yaml
+++ b/charts/cloudzero-insights-controller/templates/init-job.yaml
@@ -22,7 +22,7 @@ spec:
           args:
             - |
               while true; do
-                echo "Waiting for the tags server to be ready...";
+                echo "Waiting for the webhook server to be ready...";
                 if curl -s -o /dev/null -w "%{http_code}" -k https://{{ include "insights-controller.serviceName" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.server.service.port }}/healthz | grep -q 200; then
                   echo "Server is ready, starting scrape job...";
                   curl -X POST -k https://{{ include "insights-controller.serviceName" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.server.service.port }}/scrape;


### PR DESCRIPTION
### Description

There isn't a lot of benefit to having a subchart in the cloudzero-agent chart now that they're always used together. this PR does two things:
1. merges the insights-controller chart into the cloudzero-agent chart, and
2. renames the `tags` map to `insightsController`

todo
- [x] webhooks should be created based on resource enablement, not if they exist in the webhooks array
- [x] insightsController.enabled should turn off all related components
- [x] update documentation to reflect tags -> insightsController name change

### Checklist

- [x] I have added documentation for new/changed functionality in this PR
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`