### PR TITLE
[CP-23428] add helm chart for creating cert

### DIFF
--- a/charts/cloudzero-agent/README.md
+++ b/charts/cloudzero-agent/README.md
@@ -155,7 +155,6 @@ This chart allows the exporting of labels and annotations from the following res
 Additional Notes:
 - Labels and annotations exports are managed in the `insightsController` section of the `values.yaml` file.
 - By default, only labels from pods and namespaces are exported. To enable more resources, see the `insightsController.labels.resources` and `insightsController.annotations.resources` section of the `values.yaml` file.
-- Labels and annotations exports are managed in the `insightsController` section of the `values.yaml` file.
 - To disambiguate labels/annotations between resources, a prefix representing the resource type is prepended to the label key in the [CloudZero Explorer](https://app.cloudzero.com/explorer). For example, a `foo=bar` node label would be presented as `node:foo: bar`. The exception is pod labels which do not have resource prefixes for backward compatibility with previous versions.
 - Annotations are not exported by default; see the `insightsController.annotations.enabled` setting to enable. To disambiguate annotations from labels, an `annotation` prefix is prepended to the annotation key; i.e., an `foo: bar` annotation on a namespace would be represented in the Explorer as `node:annotation:foo: bar`
 - For both labels and annotations, the `patterns` array applies across all resource types; i.e., setting `['^foo']` for `insightsController.labels.patterns` will match label keys that start with `foo` for all resource types set to `true` in `insightsController.labels.resources`.

--- a/charts/cloudzero-agent/README.md
+++ b/charts/cloudzero-agent/README.md
@@ -284,7 +284,7 @@ kubeStateMetrics:
 |----------------------------------------------------|--------------------------|---------|
 | https://prometheus-community.github.io/helm-charts | kube-state-metrics       | 5.15.*  |
 
-Note that while `kube-state-metrics` is listed as a dependency, it is referred to as `cloudzero-state-metrics` within the helm chart. This is to enforce the idea that this KSM deployment is used exclusively by the `cloudzero-agent`
+Note that while `kube-state-metrics` is listed as a dependency, it is referred to as `cloudzero-state-metrics` within the helm chart. This is to enforce the idea that this KSM deployment is used exclusively by the `cloudzero-agent`.
 
 ## Enabling Release Notifications
 

--- a/charts/cloudzero-agent/README.md
+++ b/charts/cloudzero-agent/README.md
@@ -63,7 +63,7 @@ cloudAccountId: YOUR_CLOUD_ACCOUNT_ID
 clusterName: YOUR_CLUSTER_NAME
 # -- Region the cluster is running in.
 region: YOUR_CLOUD_REGION
-# -- CloudZero API key. Required if existingSecretName is false.
+# -- CloudZero API key. Required if existingSecretName is null.
 apiKey: YOUR_CLOUDZERO_API_KEY
 # -- If set, the agent will use the API key in this Secret to authenticate with CloudZero.
 existingSecretName: YOUR_EXISTING_API_KEY_K8S_SECRET

--- a/charts/cloudzero-agent/README.md
+++ b/charts/cloudzero-agent/README.md
@@ -153,7 +153,7 @@ This chart allows the exporting of labels and annotations from the following res
 - `Namespace`
 
 Additional Notes:
-- Labels and annotations exports are managed in the insightsController section of the values.yaml file.
+- Labels and annotations exports are managed in the `insightsController` section of the `values.yaml` file.
 - By default, only labels from pods and namespaces are exported. To enable more resources, see the `insightsController.labels.resources` and `insightsController.annotations.resources` section of the `values.yaml` file.
 - Labels and annotations exports are managed in the `insightsController` section of the `values.yaml` file.
 - To disambiguate labels/annotations between resources, a prefix representing the resource type is prepended to the label key in the [CloudZero Explorer](https://app.cloudzero.com/explorer). For example, a `foo=bar` node label would be presented as `node:foo: bar`. The exception is pod labels which do not have resource prefixes for backward compatibility with previous versions.

--- a/charts/cloudzero-agent/configuration.example.yaml
+++ b/charts/cloudzero-agent/configuration.example.yaml
@@ -4,7 +4,7 @@ cloudAccountId: null
 clusterName: null
 # -- Region the cluster is running in.
 region: null
-# -- CloudZero API key. Required if existingSecretName is false.
+# -- CloudZero API key. Required if existingSecretName is null.
 apiKey: null
 # -- If set, the agent will use the API key in this Secret to authenticate with CloudZero.
 existingSecretName: null

--- a/charts/cloudzero-agent/configuration.example.yaml
+++ b/charts/cloudzero-agent/configuration.example.yaml
@@ -4,12 +4,10 @@ cloudAccountId: null
 clusterName: null
 # -- Region the cluster is running in.
 region: null
-
-global:
-  # -- CloudZero API key. Required if useExistingSecret is false.
-  apiKey: null
-  # -- If set, the agent will use the API key in this Secret to authenticate with CloudZero.
-  existingSecretName: null
+# -- CloudZero API key. Required if existingSecretName is false.
+apiKey: null
+# -- If set, the agent will use the API key in this Secret to authenticate with CloudZero.
+existingSecretName: null
 
 # label and annotation configuration:
 insightsController:

--- a/charts/cloudzero-agent/templates/_helpers.tpl
+++ b/charts/cloudzero-agent/templates/_helpers.tpl
@@ -227,7 +227,7 @@ Name for the validating webhook configuration resource
 Name for the certificate secret
 */}}
 {{- define "cloudzero-agent.tlsSecretName" -}}
-{{- printf "%s-tls" (include "cloudzero-agent.insightsController.server.webhookFullname" .) }}
+{{- default (printf "%s-tls" (include "cloudzero-agent.insightsController.server.webhookFullname" .)) .Values.insightsController.server.tls.nameOverride }}
 {{- end }}
 
 
@@ -263,7 +263,7 @@ Annotations for the webhooks
 {{- if .Values.insightsController.webhooks.annotations }}
 {{ toYaml .Values.insightsController.webhook.annotations }}
 {{- end }}
-{{- if and .Values.insightsController.webhooks.certificate.enabled .Values.insightsController.webhooks.issuer.enabled }}
+{{- if and .Values.insightsController.certificate.enabled .Values.insightsController.issuer.enabled }}
 cert-manager.io/inject-ca-from: {{ .Values.insightsController.webhooks.caInjection | default (printf "%s/%s" .Release.Namespace (include "cloudzero-agent.certificateName" .)) }}
 {{- end }}
 {{- end }}

--- a/charts/cloudzero-agent/templates/certificate.yaml
+++ b/charts/cloudzero-agent/templates/certificate.yaml
@@ -1,4 +1,4 @@
-{{ if and .Values.insightsController.webhooks.certificate.enabled .Values.insightsController.enabled }}
+{{ if and .Values.insightsController.certificate.enabled .Values.insightsController.enabled }}
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate

--- a/charts/cloudzero-agent/templates/issuer.yaml
+++ b/charts/cloudzero-agent/templates/issuer.yaml
@@ -1,4 +1,4 @@
-{{ if and .Values.insightsController.webhooks.issuer.enabled .Values.insightsController.enabled }}
+{{ if and .Values.insightsController.issuer.enabled .Values.insightsController.enabled }}
 ---
 apiVersion: cert-manager.io/v1
 kind: Issuer
@@ -6,5 +6,5 @@ metadata:
   name: {{ include "cloudzero-agent.issuerName" . }}
   namespace: {{ .Release.Namespace }}
 spec:
-  {{- toYaml .Values.insightsController.webhooks.issuer.spec | nindent 2 }}
+  {{- toYaml .Values.insightsController.issuer.spec | nindent 2 }}
 {{- end }}

--- a/charts/cloudzero-agent/templates/webhooks.yaml
+++ b/charts/cloudzero-agent/templates/webhooks.yaml
@@ -27,7 +27,7 @@ webhooks:
         name: {{ include "cloudzero-agent.serviceName" $ }}
         path: "{{ $configs.path }}"
         port: {{ $.Values.insightsController.service.port }}
-      {{- if and $.Values.insightsController.webhooks.certificate.enabled $.Values.insightsController.webhooks.issuer.enabled }}
+      {{- if or (and $.Values.insightsController.certificate.enabled $.Values.insightsController.issuer.enabled) (gt (len $.Values.insightsController.webhooks.caBundle) 1 ) }}
       caBundle: {{ $.Values.insightsController.webhooks.caBundle }}
       {{- end }}
     admissionReviewVersions: ["v1"]

--- a/charts/cloudzero-agent/values.yaml
+++ b/charts/cloudzero-agent/values.yaml
@@ -7,7 +7,7 @@ clusterName: null
 # -- Region the cluster is running in.
 region: null
 
-# -- CloudZero API key. Required if existingSecretName is false.
+# -- CloudZero API key. Required if existingSecretName is null.
 apiKey: null
 # -- If set, the agent will use the API key in this Secret to authenticate with CloudZero.
 existingSecretName: null

--- a/charts/cloudzero-agent/values.yaml
+++ b/charts/cloudzero-agent/values.yaml
@@ -164,6 +164,7 @@ insightsController:
     tls:
       enabled: true
       useManagedCertificate: true
+      nameOverride: ""
       mountPath: /etc/certs
     port: 8443
     read_timeout: 10s
@@ -180,15 +181,15 @@ insightsController:
   podLabels: {}
   service:
     port: 443
+  issuer:
+    enabled: true
+    spec:
+      selfSigned: {}
+  certificate:
+    enabled: true
   webhooks:
     annotations: {}
     namespaceSelector: {}  # This denotes no specific selection, applies to all namespaces
-    issuer:
-      enabled: true
-      spec:
-        selfSigned: {}
-    certificate:
-      enabled: true
     caBundle: ''  # by default, this is empty, and the value is populated by cert-manager's ca-injector if cert-manager is used
     configurations:
       pods:

--- a/charts/cloudzero-agent/values.yaml
+++ b/charts/cloudzero-agent/values.yaml
@@ -7,7 +7,7 @@ clusterName: null
 # -- Region the cluster is running in.
 region: null
 
-# -- CloudZero API key. Required if useExistingSecret is false.
+# -- CloudZero API key. Required if existingSecretName is false.
 apiKey: null
 # -- If set, the agent will use the API key in this Secret to authenticate with CloudZero.
 existingSecretName: null

--- a/charts/cloudzero-certificate/.helmignore
+++ b/charts/cloudzero-certificate/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/cloudzero-certificate/Chart.yaml
+++ b/charts/cloudzero-certificate/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: cloudzero-certificate
+description: Creates a TLS certificate to be used by the CloudZero Insights Controller
+type: application
+version: 0.1.0

--- a/charts/cloudzero-certificate/templates/NOTES.txt
+++ b/charts/cloudzero-certificate/templates/NOTES.txt
@@ -1,0 +1,11 @@
+Get the caBundle value by running:
+
+CA_BUNDLE=$(kubectl get secret -n {{ .Release.Namespace }} {{ include "cloudzero-certificate.secretName" . }} -o jsonpath='{.data.ca\.crt}')
+
+This value should be used in the cloudzero-agent helm chart as shown:
+
+```
+insightsController:
+  webhooks:
+    caBundle: $CA_BUNDLE
+```

--- a/charts/cloudzero-certificate/templates/_helpers.tpl
+++ b/charts/cloudzero-certificate/templates/_helpers.tpl
@@ -1,0 +1,71 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "cloudzero-certificate.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "cloudzero-certificate.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "cloudzero-certificate.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "cloudzero-certificate.labels" -}}
+helm.sh/chart: {{ include "cloudzero-certificate.chart" . }}
+{{ include "cloudzero-certificate.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "cloudzero-certificate.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "cloudzero-certificate.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the secret to use
+*/}}
+{{- define "cloudzero-certificate.secretName" -}}
+{{- default (include "cloudzero-certificate.fullname" .) .Values.secret.name }}
+{{- end }}
+
+{{/*
+Generate certificate for the webhook server
+*/}}
+{{- define "cloudzero-certificate.genCerts" -}}
+{{- $releaseName := required "`cloudzeroAgentReleaseName` must be supplied. This value should be the name of the cloudzero-agent helm release that will be created" .Values.cloudzeroAgentReleaseName -}}
+{{- $dnsName :=  printf "%s-svc.%s.cluster.local" $releaseName $.Release.Namespace -}}
+{{- $ca := genCA "cloudzero-agent-ca" 365 -}}
+{{- $cert := genSignedCert $dnsName nil (list $dnsName) 9999999 $ca -}}
+ca.crt: {{ $cert.Cert | b64enc }}
+tls.crt: {{ $cert.Cert | b64enc }}
+tls.key: {{ $cert.Key | b64enc }}
+{{- end -}}

--- a/charts/cloudzero-certificate/templates/secret.yaml
+++ b/charts/cloudzero-certificate/templates/secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    {{- include "cloudzero-certificate.labels" . | nindent 4 }}
+  name: {{ include "cloudzero-certificate.secretName" . }}
+  namespace: {{ .Release.Namespace }}
+data:
+{{- include "cloudzero-certificate.genCerts" . | nindent 2 }}

--- a/charts/cloudzero-certificate/values.yaml
+++ b/charts/cloudzero-certificate/values.yaml
@@ -1,0 +1,13 @@
+cloudzeroAgentReleaseName: null
+
+nameOverride: ""
+fullnameOverride: ""
+
+secret:
+  name: ""
+
+serviceAccount:
+  name: ""
+
+role:
+  name: ""


### PR DESCRIPTION
### Description
one part of the beta feedback was that relying on cert-manager is not always easy. cert-manager should still be the preferred approach, but we also want to provide a quick way for users to test. This PR adds a helm chart that generates a self signed cert for the webhook server

### Checklist

- [x] I have added documentation for new/changed functionality in this PR
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`