### PR TITLE
CP 24028 add insights controller scape config

### DIFF
--- a/.github/workflows/build-and-publish-beta-chart.yml
+++ b/.github/workflows/build-and-publish-beta-chart.yml
@@ -5,9 +5,8 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version to use for the release (beta suffix will be automatically appended (e.g. "0.0.1" + "-beta"))'
-        required: false
-        default: ''
+        description: 'Version to use for the release. Must contain "beta" (e.g. "0.0.1-beta").'
+        required: true
       branch:
         description: 'Branch to use for the release'
         required: true
@@ -54,18 +53,18 @@ jobs:
       - name: Package Cloudzero Agent Chart
         run: helm package charts/cloudzero-agent/ --destination .deploy
 
-      # Step 3: Determine Version
-      - name: Get Github Tag Version
-        id: version
-        uses: flatherskevin/semver-action@v1
-        with:
-          incrementLevel: patch
-          source: tags
-
-      - name: Determine Chart Version
+      # Step 3: Validate and Set Version
+      - name: Validate Input Version
         run: |
-          NEW_VERSION=${{ github.event.inputs.version || steps.version.outputs.nextVersion }}
-          echo "NEW_VERSION=$NEW_VERSION-beta" >> $GITHUB_ENV
+          if [[ -z "${{ github.event.inputs.version }}" ]]; then
+            echo "Version input is required."
+            exit 1
+          fi
+          if [[ "${{ github.event.inputs.version }}" != *"beta"* ]]; then
+            echo "Version must contain 'beta'. Provided version: ${{ github.event.inputs.version }}"
+            exit 1
+          fi
+          echo "NEW_VERSION=${{ github.event.inputs.version }}" >> $GITHUB_ENV
 
       - name: Update Chart Version
         run: |
@@ -128,7 +127,6 @@ jobs:
 
       - name: Save Index in GH Pages
         run: |
-          # copy the new chart and index.yaml
           git add beta
           git commit -m "Updating ${{ env.NEW_VERSION }} Index"
           git push origin gh-pages

--- a/charts/cloudzero-agent/README.md
+++ b/charts/cloudzero-agent/README.md
@@ -76,6 +76,7 @@ Alternatively, [install the cert-manager CRDs directly](https://cert-manager.io/
 kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.16.2/cert-manager.yaml
 ```
 
+Alternatively, [install the cert-manager CRDs directly](https://cert-manager.io/docs/installation/helm/).
 
 3. Fill out all required fields in the `configuration.example.yaml` file in this directory. Rename the file as necessary. Below is an example of a completed configuration file:
 ```yaml

--- a/charts/cloudzero-agent/README.md
+++ b/charts/cloudzero-agent/README.md
@@ -76,8 +76,6 @@ Alternatively, [install the cert-manager CRDs directly](https://cert-manager.io/
 kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.16.2/cert-manager.yaml
 ```
 
-Alternatively, [install the cert-manager CRDs directly](https://cert-manager.io/docs/installation/helm/).
-
 3. Fill out all required fields in the `configuration.example.yaml` file in this directory. Rename the file as necessary. Below is an example of a completed configuration file:
 ```yaml
 # -- Account ID of the account the cluster is running in. This must be a string - even if it is a number in your system.

--- a/charts/cloudzero-agent/README.md
+++ b/charts/cloudzero-agent/README.md
@@ -17,14 +17,36 @@ For the latest release, see [Releases](https://github.com/Cloudzero/cloudzero-ch
 
 ## Installation
 
-### Get Helm Repository Info
+### Adding Helm Repository Information
+
+To use the chart or a beta version, you must add the repository to Helm. Refer to the [`helm repo`](https://helm.sh/docs/helm/helm_repo/) documentation for command details.
+
+#### 1. Add the Helm Chart Repository
 
 ```console
 helm repo add cloudzero https://cloudzero.github.io/cloudzero-charts
-helm repo update
+```
+> Note: If you intend to use a beta version, refer to the [beta installation document](./BETA-INSTALLATION.md) for the appropriate channel.
+
+#### 2. Add Repository Dependencies
+
+**Cert Manager**
+```console
+helm repo add cert-manager https://charts.jetstack.io    
 ```
 
-_See [`helm repo`](https://helm.sh/docs/helm/helm_repo/) for command documentation._
+**Metrics Exporter**
+```console
+helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+```
+
+#### 3. Update the Helm Repositories
+
+Ensure that the most recent chart versions are available:
+
+```console
+helm repo update
+```
 
 ### Install Helm Chart
 
@@ -53,7 +75,7 @@ Alternatively, [install the cert-manager CRDs directly](https://cert-manager.io/
 ```console
 kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.16.2/cert-manager.yaml
 ```
-Alternatively, [install the cert-manager CRDs directly](https://cert-manager.io/docs/installation/helm/).
+
 
 3. Fill out all required fields in the `configuration.example.yaml` file in this directory. Rename the file as necessary. Below is an example of a completed configuration file:
 ```yaml

--- a/charts/cloudzero-agent/docs/releases/1.0.0-beta-4.md
+++ b/charts/cloudzero-agent/docs/releases/1.0.0-beta-4.md
@@ -1,11 +1,11 @@
-## [1.0.4-beta](https://github.com/Cloudzero/cloudzero-agent/compare/v1.0.1-beta...v1.0.4-beta) (2024-12-12)
+## [1.0.0-beta-4](https://github.com/Cloudzero/cloudzero-agent/compare/v1.0.1-beta...v1.0.0-beta-4) (2024-12-12)
 
 The Insights controller now exposes a Prometheus Metrics endpoint, enabling CloudZero to monitor its operations.
 
 ### Upgrade Steps
 * Upgrade with:
 ```sh
-helm upgrade --install <RELEASE_NAME> cloudzero-beta/cloudzero-agent -n <NAMESPACE> --create-namespace -f configuration.example.yaml --version 1.0.4-beta
+helm upgrade --install <RELEASE_NAME> cloudzero-beta/cloudzero-agent -n <NAMESPACE> --create-namespace -f configuration.example.yaml --version 1.0.0-beta-1
 ```
 For more details, see the [beta installation instructions](https://github.com/Cloudzero/cloudzero-charts/blob/develop/charts/cloudzero-agent/BETA-INSTALLATION.md).
 

--- a/charts/cloudzero-agent/docs/releases/1.0.4-beta.md
+++ b/charts/cloudzero-agent/docs/releases/1.0.4-beta.md
@@ -1,13 +1,13 @@
 ## [1.0.4-beta](https://github.com/Cloudzero/cloudzero-agent/compare/v1.0.1-beta...v1.0.4-beta) (2024-12-12)
 
-The Insights controller now exposes a Prometheus Metrics endpoint to enable monitoring of the insights controller operations by CloudZero.
+The Insights controller now exposes a Prometheus Metrics endpoint, enabling CloudZero to monitor its operations.
 
 ### Upgrade Steps
 * Upgrade with:
 ```sh
 helm upgrade --install <RELEASE_NAME> cloudzero-beta/cloudzero-agent -n <NAMESPACE> --create-namespace -f configuration.example.yaml --version 1.0.4-beta
 ```
-See the [beta installation instructions](https://github.com/Cloudzero/cloudzero-charts/blob/develop/charts/cloudzero-agent/BETA-INSTALLATION.md) for further detail
+For more details, see the [beta installation instructions](https://github.com/Cloudzero/cloudzero-charts/blob/develop/charts/cloudzero-agent/BETA-INSTALLATION.md).
 
 ### Improvements
-* Add insights controller scrape configuration enabling operational monitoring. More information on [available statistics in the insights controller documentation](https://github.com/Cloudzero/cloudzero-insights-controller/blob/develop/docs/statistics.md).
+* Added insights controller scrape configuration for operational monitoring. More information is available in the [insights controller documentation](https://github.com/Cloudzero/cloudzero-insights-controller/blob/develop/docs/statistics.md).

--- a/charts/cloudzero-agent/docs/releases/1.0.4-beta.md
+++ b/charts/cloudzero-agent/docs/releases/1.0.4-beta.md
@@ -1,0 +1,13 @@
+## [1.0.4-beta](https://github.com/Cloudzero/cloudzero-agent/compare/v1.0.1-beta...v1.0.4-beta) (2024-12-12)
+
+The Insights controller now exposes a Prometheus Metrics endpoint to enable monitoring of the insights controller operations by CloudZero.
+
+### Upgrade Steps
+* Upgrade with:
+```sh
+helm upgrade --install <RELEASE_NAME> cloudzero-beta/cloudzero-agent -n <NAMESPACE> --create-namespace -f configuration.example.yaml --version 1.0.4-beta
+```
+See the [beta installation instructions](https://github.com/Cloudzero/cloudzero-charts/blob/develop/charts/cloudzero-agent/BETA-INSTALLATION.md) for further detail
+
+### Improvements
+* Add insights controller scrape configuration enabling operational monitoring. More information on [available statistics in the insights controller documentation](https://github.com/Cloudzero/cloudzero-insights-controller/blob/develop/docs/statistics.md).

--- a/charts/cloudzero-agent/templates/cm.yaml
+++ b/charts/cloudzero-agent/templates/cm.yaml
@@ -120,7 +120,7 @@ data:
           enable_http2: true
       {{- end }}
       {{- if .Values.insightsController.enabled }}
-      - job_name: '{{ include "cloudzero-agent.insightsController.server.webhookFullname" . }}'
+      - job_name: cloudzero-insights-controller-job
         metrics_path: /metrics
         scheme: https
         enable_compression: true

--- a/charts/cloudzero-agent/templates/cm.yaml
+++ b/charts/cloudzero-agent/templates/cm.yaml
@@ -118,11 +118,30 @@ data:
           kubeconfig_file: ""
           follow_redirects: true
           enable_http2: true
-    {{- end }}
-    {{- if .Values.prometheusConfig.scrapeJobs.additionalScrapeJobs -}}
-    {{ toYaml .Values.prometheusConfig.scrapeJobs.additionalScrapeJobs | toString | nindent 6 }}
-    {{- end}}
-    {{- end}}
+      {{- end }}
+      {{- if .Values.insightsController.enabled }}
+      - job_name: '{{ include "cloudzero-agent.insightsController.server.webhookFullname" . }}'
+        metrics_path: /metrics
+        scheme: https
+        enable_compression: true
+        tls_config:
+          insecure_skip_verify: true
+        follow_redirects: true
+        enable_http2: true
+        kubernetes_sd_configs:
+          - role: endpoints
+            kubeconfig_file: ""
+            follow_redirects: true
+            enable_http2: true
+        relabel_configs:
+          - source_labels: [__meta_kubernetes_endpoints_name]
+            action: keep
+            regex: {{ include "cloudzero-agent.insightsController.server.webhookFullname" . }}-svc
+      {{- end }}
+      {{- if .Values.prometheusConfig.scrapeJobs.additionalScrapeJobs -}}
+      {{ toYaml .Values.prometheusConfig.scrapeJobs.additionalScrapeJobs | toString | nindent 6 }}
+      {{- end}}
+  {{- end}}
     remote_write:
       - url: 'https://{{ include "cloudzero-agent.cleanString" .Values.host }}/v1/container-metrics?cluster_name={{ include "cloudzero-agent.cleanString" .Values.clusterName | urlquery }}&cloud_account_id={{ include "cloudzero-agent.cleanString" .Values.cloudAccountId | urlquery }}&region={{ include "cloudzero-agent.cleanString" .Values.region | urlquery }}'
         authorization:

--- a/charts/cloudzero-agent/values.yaml
+++ b/charts/cloudzero-agent/values.yaml
@@ -159,7 +159,7 @@ insightsController:
     replicaCount: 3
     image:
       repository: ghcr.io/cloudzero/cloudzero-insights-controller/cloudzero-insights-controller
-      tag: 0.0.2
+      tag: 0.0.3
       pullPolicy: Always
     tls:
       enabled: true


### PR DESCRIPTION
### Description

- **CP-24028: add scrape target for insights container**
- **CP-22734: Bump insights image release version**
- **Enhance README for helm repo management**
- **Add release note for next beta version**
- **Update release process for customer version numbers in betas**


### Testing

1. Deploy small cluster
    ```yaml
    apiVersion: eksctl.io/v1alpha5
    kind: ClusterConfig

    metadata:
      name: aws-cirrus-jb-insights-cluster
      region: us-east-2

    iam:
      withOIDC: true

    addons:
      - name: vpc-cni
        version: latest
      - name: kube-proxy
        version: latest
      - name: coredns
        version: latest

    nodeGroups:
      - name: ng-1
        instanceType: t3.small
        desiredCapacity: 2
        volumeSize: 20
        amiFamily: Bottlerocket
    ```
    ```sh
    eksctl create cluster -f insights-cluster.yaml
    ```

2. Deploy cert manager
    ```sh
    kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.16.2/cert-manager.yaml
   ```

3. Create configuration for overrides
   ```yaml
    cloudAccountId: |-
      975482786146
    clusterName: aws-cirrus-jb-insights-cluster
    region: us-east-2
    existingSecretName: cloudzero-api-key

    server:
      args:
        - --config.file=/etc/config/prometheus/configmaps/prometheus.yml
        - --web.enable-lifecycle
        - --web.console.libraries=/etc/prometheus/console_libraries
        - --web.console.templates=/etc

    insightsController:
      enabled: true
      server:
        image:
          tag: dev-ff25286d1f1e6625bde33236d0ad639874cf5d4a
      labels:
        enabled: true
        patterns:
          - '.*'
      annotations:
        enabled: false
        patterns:
          - '.*'

    cert-manager:
      # -- Your cluster may already have cert-manager running, in which case this value can be set to false.
      enabled: false
   ```

4. Deploy the Agent
    ```sh
    helm upgrade --install cloudzero-agent . -f override.yaml
    ```

5. Forward the prometheus UI port
    ```sh
    kubectl port-forward svc/cloudzero-prometheus-server 9090:9090
    ```

  **Target Confirmation**
<img width="2052" alt="testing-metrics" src="https://github.com/user-attachments/assets/7a5c0933-4c46-4cd4-b438-5664cd5bb94f" />

  **Metrics Validation**
<img width="2056" alt="testing-targets" src="https://github.com/user-attachments/assets/3481c6fc-dbc0-4522-87fd-3e45338b65d0" />

**Manual Curl**
```sh
curl -k https://localhost:8443/metrics
# HELP go_gc_duration_seconds A summary of the wall-time pause (stop-the-world) duration in garbage collection cycles.
# TYPE go_gc_duration_seconds summary
go_gc_duration_seconds{quantile="0"} 4.5535e-05
go_gc_duration_seconds{quantile="0.25"} 4.5535e-05
go_gc_duration_seconds{quantile="0.5"} 0.000107022
go_gc_duration_seconds{quantile="0.75"} 0.000107022
go_gc_duration_seconds{quantile="1"} 0.000107022
go_gc_duration_seconds_sum 0.000152557
go_gc_duration_seconds_count 2
# HELP go_gc_gogc_percent Heap size target percentage configured by the user, otherwise 100. This value is set by the GOGC environment variable, and the runtime/debug.SetGCPercent function. Sourced from /gc/gogc:percent
# TYPE go_gc_gogc_percent gauge
go_gc_gogc_percent 100
# HELP go_gc_gomemlimit_bytes Go runtime memory limit configured by the user, otherwise math.MaxInt64. This value is set by the GOMEMLIMIT environment variable, and the runtime/debug.SetMemoryLimit function. Sourced from /gc/gomemlimit:bytes
# TYPE go_gc_gomemlimit_bytes gauge
go_gc_gomemlimit_bytes 9.223372036854776e+18
# HELP go_goroutines Number of goroutines that currently exist.
# TYPE go_goroutines gauge
go_goroutines 13
# HELP go_info Information about the Go environment.
# TYPE go_info gauge
go_info{version="go1.23.4"} 1
# HELP go_memstats_alloc_bytes Number of bytes allocated in heap and currently in use. Equals to /memory/classes/heap/objects:bytes.
# TYPE go_memstats_alloc_bytes gauge
go_memstats_alloc_bytes 2.873816e+06
# HELP go_memstats_alloc_bytes_total Total number of bytes allocated in heap until now, even if released already. Equals to /gc/heap/allocs:bytes.
# TYPE go_memstats_alloc_bytes_total counter
go_memstats_alloc_bytes_total 5.175832e+06
# HELP go_memstats_buck_hash_sys_bytes Number of bytes used by the profiling bucket hash table. Equals to /memory/classes/profiling/buckets:bytes.
# TYPE go_memstats_buck_hash_sys_bytes gauge
go_memstats_buck_hash_sys_bytes 5934
# HELP go_memstats_frees_total Total number of heap objects frees. Equals to /gc/heap/frees:objects + /gc/heap/tiny/allocs:objects.
# TYPE go_memstats_frees_total counter
go_memstats_frees_total 21504
# HELP go_memstats_gc_sys_bytes Number of bytes used for garbage collection system metadata. Equals to /memory/classes/metadata/other:bytes.
# TYPE go_memstats_gc_sys_bytes gauge
go_memstats_gc_sys_bytes 3.106e+06
# HELP go_memstats_heap_alloc_bytes Number of heap bytes allocated and currently in use, same as go_memstats_alloc_bytes. Equals to /memory/classes/heap/objects:bytes.
# TYPE go_memstats_heap_alloc_bytes gauge
go_memstats_heap_alloc_bytes 2.873816e+06
# HELP go_memstats_heap_idle_bytes Number of heap bytes waiting to be used. Equals to /memory/classes/heap/released:bytes + /memory/classes/heap/free:bytes.
# TYPE go_memstats_heap_idle_bytes gauge
go_memstats_heap_idle_bytes 2.842624e+06
# HELP go_memstats_heap_inuse_bytes Number of heap bytes that are in use. Equals to /memory/classes/heap/objects:bytes + /memory/classes/heap/unused:bytes
# TYPE go_memstats_heap_inuse_bytes gauge
go_memstats_heap_inuse_bytes 5.054464e+06
# HELP go_memstats_heap_objects Number of currently allocated objects. Equals to /gc/heap/objects:objects.
# TYPE go_memstats_heap_objects gauge
go_memstats_heap_objects 14286
# HELP go_memstats_heap_released_bytes Number of heap bytes released to OS. Equals to /memory/classes/heap/released:bytes.
# TYPE go_memstats_heap_released_bytes gauge
go_memstats_heap_released_bytes 2.809856e+06
# HELP go_memstats_heap_sys_bytes Number of heap bytes obtained from system. Equals to /memory/classes/heap/objects:bytes + /memory/classes/heap/unused:bytes + /memory/classes/heap/released:bytes + /memory/classes/heap/free:bytes.
# TYPE go_memstats_heap_sys_bytes gauge
go_memstats_heap_sys_bytes 7.897088e+06
# HELP go_memstats_last_gc_time_seconds Number of seconds since 1970 of last garbage collection.
# TYPE go_memstats_last_gc_time_seconds gauge
go_memstats_last_gc_time_seconds 1.733965659533795e+09
# HELP go_memstats_mallocs_total Total number of heap objects allocated, both live and gc-ed. Semantically a counter version for go_memstats_heap_objects gauge. Equals to /gc/heap/allocs:objects + /gc/heap/tiny/allocs:objects.
# TYPE go_memstats_mallocs_total counter
go_memstats_mallocs_total 35790
# HELP go_memstats_mcache_inuse_bytes Number of bytes in use by mcache structures. Equals to /memory/classes/metadata/mcache/inuse:bytes.
# TYPE go_memstats_mcache_inuse_bytes gauge
go_memstats_mcache_inuse_bytes 2400
# HELP go_memstats_mcache_sys_bytes Number of bytes used for mcache structures obtained from system. Equals to /memory/classes/metadata/mcache/inuse:bytes + /memory/classes/metadata/mcache/free:bytes.
# TYPE go_memstats_mcache_sys_bytes gauge
go_memstats_mcache_sys_bytes 15600
# HELP go_memstats_mspan_inuse_bytes Number of bytes in use by mspan structures. Equals to /memory/classes/metadata/mspan/inuse:bytes.
# TYPE go_memstats_mspan_inuse_bytes gauge
go_memstats_mspan_inuse_bytes 85120
# HELP go_memstats_mspan_sys_bytes Number of bytes used for mspan structures obtained from system. Equals to /memory/classes/metadata/mspan/inuse:bytes + /memory/classes/metadata/mspan/free:bytes.
# TYPE go_memstats_mspan_sys_bytes gauge
go_memstats_mspan_sys_bytes 97920
# HELP go_memstats_next_gc_bytes Number of heap bytes when next garbage collection will take place. Equals to /gc/heap/goal:bytes.
# TYPE go_memstats_next_gc_bytes gauge
go_memstats_next_gc_bytes 5.781872e+06
# HELP go_memstats_other_sys_bytes Number of bytes used for other system allocations. Equals to /memory/classes/other:bytes.
# TYPE go_memstats_other_sys_bytes gauge
go_memstats_other_sys_bytes 664738
# HELP go_memstats_stack_inuse_bytes Number of bytes obtained from system for stack allocator in non-CGO environments. Equals to /memory/classes/heap/stacks:bytes.
# TYPE go_memstats_stack_inuse_bytes gauge
go_memstats_stack_inuse_bytes 491520
# HELP go_memstats_stack_sys_bytes Number of bytes obtained from system for stack allocator. Equals to /memory/classes/heap/stacks:bytes + /memory/classes/os-stacks:bytes.
# TYPE go_memstats_stack_sys_bytes gauge
go_memstats_stack_sys_bytes 491520
# HELP go_memstats_sys_bytes Number of bytes obtained from system. Equals to /memory/classes/total:byte.
# TYPE go_memstats_sys_bytes gauge
go_memstats_sys_bytes 1.22788e+07
# HELP go_sched_gomaxprocs_threads The current runtime.GOMAXPROCS setting, or the number of operating system threads that can execute user-level Go code simultaneously. Sourced from /sched/gomaxprocs:threads
# TYPE go_sched_gomaxprocs_threads gauge
go_sched_gomaxprocs_threads 2
# HELP go_threads Number of OS threads created.
# TYPE go_threads gauge
go_threads 8
# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
# TYPE process_cpu_seconds_total counter
process_cpu_seconds_total 0.04
# HELP process_max_fds Maximum number of open file descriptors.
# TYPE process_max_fds gauge
process_max_fds 1.048576e+06
# HELP process_network_receive_bytes_total Number of bytes received by the process over the network.
# TYPE process_network_receive_bytes_total counter
process_network_receive_bytes_total 2684
# HELP process_network_transmit_bytes_total Number of bytes sent by the process over the network.
# TYPE process_network_transmit_bytes_total counter
process_network_transmit_bytes_total 2684
# HELP process_open_fds Number of open file descriptors.
# TYPE process_open_fds gauge
process_open_fds 8
# HELP process_resident_memory_bytes Resident memory size in bytes.
# TYPE process_resident_memory_bytes gauge
process_resident_memory_bytes 3.6540416e+07
# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
# TYPE process_start_time_seconds gauge
process_start_time_seconds 1.73396565906e+09
# HELP process_virtual_memory_bytes Virtual memory size in bytes.
# TYPE process_virtual_memory_bytes gauge
process_virtual_memory_bytes 1.35458816e+09
# HELP process_virtual_memory_max_bytes Maximum amount of virtual memory available in bytes.
# TYPE process_virtual_memory_max_bytes gauge
process_virtual_memory_max_bytes 1.8446744073709552e+19
# HELP promhttp_metric_handler_requests_in_flight Current number of scrapes being served.
# TYPE promhttp_metric_handler_requests_in_flight gauge
promhttp_metric_handler_requests_in_flight 1
# HELP promhttp_metric_handler_requests_total Total number of scrapes by HTTP status code.
# TYPE promhttp_metric_handler_requests_total counter
promhttp_metric_handler_requests_total{code="200"} 0
promhttp_metric_handler_requests_total{code="500"} 0
promhttp_metric_handler_requests_total{code="503"} 0
```

### Checklist

- [x] I have added documentation for new/changed functionality in this PR
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`

[CP-23425]: https://cloudzero.atlassian.net/browse/CP-23425?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CP-23429]: https://cloudzero.atlassian.net/browse/CP-23429?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ