### PR TITLE
CP 24008

### DIFF
--- a/charts/cloudzero-agent/templates/_helpers.tpl
+++ b/charts/cloudzero-agent/templates/_helpers.tpl
@@ -140,7 +140,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 Combine metric lists
 */}}
 {{- define "cloudzero-agent.combineMetrics" -}}
-{{- $total := concat .Values.kubeMetrics .Values.containerMetrics -}}
+{{- $total := concat .Values.kubeMetrics .Values.containerMetrics .Values.insightsMetrics -}}
 {{- $result := join "|" $total -}}
 {{- $result -}}
 {{- end -}}

--- a/charts/cloudzero-agent/values.yaml
+++ b/charts/cloudzero-agent/values.yaml
@@ -26,6 +26,31 @@ containerMetrics:
   - container_memory_working_set_bytes
   - container_network_receive_bytes_total
   - container_network_transmit_bytes_total
+insightsMetrics:
+  - go_memstats_alloc_bytes
+  - go_memstats_heap_alloc_bytes
+  - go_memstats_heap_idle_bytes
+  - go_memstats_heap_inuse_bytes
+  - go_memstats_heap_objects
+  - go_memstats_last_gc_time_seconds
+  - go_memstats_alloc_bytes
+  - go_memstats_stack_inuse_bytes
+  - go_goroutines
+  - process_cpu_seconds_total
+  - process_max_fds
+  - process_open_fds
+  - process_resident_memory_bytes
+  - process_start_time_seconds
+  - process_virtual_memory_bytes
+  - process_virtual_memory_max_bytes
+  - remote_write_timeseries_total
+  - remote_write_response_codes_total
+  - remote_write_payload_size_bytes
+  - remote_write_failures_total
+  - remote_write_records_processed_total
+  - remote_write_db_failures_total
+  - http_requests_total
+
 
 # -- Any items added to this array will be added to the metrics that are sent to CloudZero, in addition to the minimal labels that CloudZero requires.
 additionalMetricLabels: []


### PR DESCRIPTION
### Why
Forwarding our application metrics to the platform enables us to monitor our application performance and be proactive when we detect operational or runtime issues.

### Description
1. Add `insightsMetrics` section to values.yaml for easy management of list of app metrics we care about
2. Update the helper to concatenate in the new list

### Testing

1. Deploy
3. Inspect scrape configuration forwarding line is correct:
```yaml
remote_write:
- url: https://api.cloudzero.com/v1/container-metrics?cluster_name=aws-cirrus-jb-insights-cluster&cloud_account_id=975482786146&region=us-east-2
  remote_timeout: 30s
  write_relabel_configs:
  - source_labels: [__name__]
    separator: ;
    regex: ^(kube_node_info|kube_node_status_capacity|kube_pod_container_resource_limits|kube_pod_container_resource_requests|kube_pod_labels|kube_pod_info|container_cpu_usage_seconds_total|container_memory_working_set_bytes|container_network_receive_bytes_total|container_network_transmit_bytes_total|go_memstats_alloc_bytes|go_memstats_heap_alloc_bytes|go_memstats_heap_idle_bytes|go_memstats_heap_inuse_bytes|go_memstats_heap_objects|go_memstats_last_gc_time_seconds|go_memstats_alloc_bytes|go_memstats_stack_inuse_bytes|go_goroutines|process_cpu_seconds_total|process_max_fds|process_open_fds|process_resident_memory_bytes|process_start_time_seconds|process_virtual_memory_bytes|process_virtual_memory_max_bytes|remote_write_timeseries_total|remote_write_response_codes_total|remote_write_payload_size_bytes|remote_write_failures_total|remote_write_records_processed_total|remote_write_db_failures_total|http_requests_total)$
    replacement: $1
    action: keep
  authorization:
  ```
### Checklist

- [x] I have added documentation for new/changed functionality in this PR
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`