### PR TITLE
[CP-24423] update readme, add extra svc names to cloudzero-cert, add cloudzero-cert chart publish

### DIFF
--- a/.github/workflows/build-and-publish-beta-chart.yml
+++ b/.github/workflows/build-and-publish-beta-chart.yml
@@ -41,11 +41,11 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@v3
 
-      - name: Build Insights Controller Dependencies
-        run: helm dependency update charts/cloudzero-insights-controller/
+      - name: Build cloudzero-certificate Dependencies
+        run: helm dependency update charts/cloudzero-certificate/
 
-      - name: Package Insights Controller Chart
-        run: helm package charts/cloudzero-insights-controller/ --destination .deploy
+      - name: Package cloudzero-certificate Chart
+        run: helm package charts/cloudzero-certificate/ --destination .deploy
 
       - name: Build Cloudzero Agent Dependencies
         run: helm dependency update charts/cloudzero-agent/
@@ -71,10 +71,10 @@ jobs:
           VERSION_LINE=$(awk '/version:/ && !done {print NR; done=1}' charts/cloudzero-agent/Chart.yaml)
           sed -i ''$VERSION_LINE's/.*/version: ${{ env.NEW_VERSION }}/' charts/cloudzero-agent/Chart.yaml
 
-      - name: Update Chart Version for insights-controller
+      - name: Update Chart Version for cloudzero-certificate
         run: |
-          VERSION_LINE=$(awk '/version:/ && !done {print NR; done=1}' charts/cloudzero-insights-controller/Chart.yaml)
-          sed -i ''$VERSION_LINE's/.*/version: ${{ env.NEW_VERSION }}/' charts/cloudzero-insights-controller/Chart.yaml
+          VERSION_LINE=$(awk '/version:/ && !done {print NR; done=1}' charts/cloudzero-certificate/Chart.yaml)
+          sed -i ''$VERSION_LINE's/.*/version: ${{ env.NEW_VERSION }}/' charts/cloudzero-certificate/Chart.yaml
 
       - name: Validate Release Notes are Present
         run: |
@@ -87,7 +87,7 @@ jobs:
       - name: Package Chart
         run: |
           helm package charts/cloudzero-agent/ --destination .deploy
-          helm package charts/cloudzero-insights-controller/ --destination .deploy
+          helm package charts/cloudzero-certificatecontroller/ --destination .deploy
 
       - name: Commit updated Chart.yaml
         run: |
@@ -102,8 +102,8 @@ jobs:
       - name: Upload Insight Controller Chart as Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: insights-controller-chart
-          path: .deploy/cloudzero-insights-controller-${{ env.NEW_VERSION }}.tgz
+          name: cloudzero-certificate
+          path: .deploy/cloudzero-certificate-${{ env.NEW_VERSION }}.tgz
 
       - name: Upload Cloudzero Agent Chart as Artifact
         uses: actions/upload-artifact@v4
@@ -118,7 +118,7 @@ jobs:
 
       - name: Move release Tarball
         run: |
-          cp .deploy/cloudzero-insights-controller-${{ env.NEW_VERSION }}.tgz ./beta/
+          cp .deploy/cloudzero-certificate-${{ env.NEW_VERSION }}.tgz ./beta/
           cp .deploy/cloudzero-agent-${{ env.NEW_VERSION }}.tgz ./beta/
           rm -fr .deploy
 

--- a/charts/cloudzero-agent/README.md
+++ b/charts/cloudzero-agent/README.md
@@ -201,7 +201,7 @@ The `cloudzero-certificate` chart, which is maintained in this repo, creates a c
 helm repo update
 
 # Install the chart, which creates a Secret with a TLS certificate
-helm upgrade --install --namespace <YOUR_NAMESPACE> <YOUR_RELEASE_NAME> cloudzero --set cloudzeroAgentReleaseName=<EXAMPLE_CLOUDZERO_AGENT_RELEASE_NAME>
+helm upgrade --install --namespace <YOUR_NAMESPACE> <YOUR_RELEASE_NAME> cloudzero/cloudzero-certificate --set cloudzeroAgentReleaseName=<EXAMPLE_CLOUDZERO_AGENT_RELEASE_NAME>
 
 # Get the CA bundle value by running:
 CA_BUNDLE=$(kubectl get secret -n <YOUR_NAMESPACE> <YOUR_RELEASE_NAME>-cloudzero-certificate -o jsonpath='{.data.ca\.crt}')

--- a/charts/cloudzero-certificate/templates/_helpers.tpl
+++ b/charts/cloudzero-certificate/templates/_helpers.tpl
@@ -62,9 +62,11 @@ Generate certificate for the webhook server
 */}}
 {{- define "cloudzero-certificate.genCerts" -}}
 {{- $releaseName := required "`cloudzeroAgentReleaseName` must be supplied. This value should be the name of the cloudzero-agent helm release that will be created" .Values.cloudzeroAgentReleaseName -}}
-{{- $dnsName :=  printf "%s-svc.%s.cluster.local" $releaseName $.Release.Namespace -}}
+{{- $dnsName :=  printf "%s-svc.%s.svc.cluster.local" $releaseName $.Release.Namespace -}}
+{{- $dnsNameDefault :=  printf "%s-webhook-server-svc.%s.svc.cluster.local" $releaseName $.Release.Namespace -}}
+{{- $dnsNameShort :=  printf "%s-webhook-server-svc" $releaseName -}}
 {{- $ca := genCA "cloudzero-agent-ca" 365 -}}
-{{- $cert := genSignedCert $dnsName nil (list $dnsName) 9999999 $ca -}}
+{{- $cert := genSignedCert $dnsName nil (list $dnsName $dnsNameDefault $dnsNameShort) 9999999 $ca -}}
 ca.crt: {{ $cert.Cert | b64enc }}
 tls.crt: {{ $cert.Cert | b64enc }}
 tls.key: {{ $cert.Key | b64enc }}


### PR DESCRIPTION

### Description

if we want to allow the user of the cloudzero-certificate chart, we need to publish it. this PR does that, as well as makes sure that multiple cases are coverage for the cert dns name


### Testing
in progress

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`