### PR TITLE
CP-24743: allow all resources to use imagePullSecrets

### DIFF
--- a/charts/cloudzero-agent/docs/releases/1.0.0-beta-8.md
+++ b/charts/cloudzero-agent/docs/releases/1.0.0-beta-8.md
@@ -1,0 +1,18 @@
+## [Release 1.0.0-beta-7](https://github.com/Cloudzero/cloudzero-agent/compare/v0.0.28...v1.0.0-beta-8) (2025-01-14)
+
+This release adds the `imagePullSecrets` field to the `initCertJob` so that the pod from the job can use an image from a private repository. Additionally, the `imagePullSecrets` setting for `insightsController`, `initCertJob`, and `initScrapeJob` now have reasonable default values in the case that they are not set.
+
+### Upgrade Steps
+* If required, set the `initCertJob.imagePullSecrets` to the desired value.
+* Alternatively, set only the top level `imagePullSecrets` to configure all pods to use that `imagePullSecrets` setting.
+
+Upgrade using the following command:
+```console
+helm upgrade --install <RELEASE_NAME> cloudzero-beta/cloudzero-agent -n <NAMESPACE> --create-namespace -f configuration.example.yaml --version 1.0.0-beta-8
+```
+
+### Bug Fixes
+* **imagePullSecrets Field Added to initCertJob:** The `initCertJob` Job previously did not allow for an `imagePullSecrets` to be configured, preventing use with private registries.
+
+### Improvements
+* **Default Settings for Images:** If `imagePullSecrets` is not set in the `insightsController`, `initCertJob`, and `initScrapeJob` sections, the value from `insightsController.imagePullSecrets` or the top level `imagePullSecrets` will be used; this reduces the amount of configuration needed.

--- a/charts/cloudzero-agent/docs/releases/1.0.0-beta-8.md
+++ b/charts/cloudzero-agent/docs/releases/1.0.0-beta-8.md
@@ -1,4 +1,4 @@
-## [Release 1.0.0-beta-7](https://github.com/Cloudzero/cloudzero-agent/compare/v0.0.28...v1.0.0-beta-8) (2025-01-14)
+## [Release 1.0.0-beta-8](https://github.com/Cloudzero/cloudzero-agent/compare/v0.0.28...v1.0.0-beta-8) (2025-01-14)
 
 This release adds the `imagePullSecrets` field to the `initCertJob` so that the pod from the job can use an image from a private repository. Additionally, the `imagePullSecrets` setting for `insightsController`, `initCertJob`, and `initScrapeJob` now have reasonable default values in the case that they are not set.
 

--- a/charts/cloudzero-agent/templates/_helpers.tpl
+++ b/charts/cloudzero-agent/templates/_helpers.tpl
@@ -217,7 +217,7 @@ imagePullSecrets for the insights controller webhook server
 {{- else if .Values.imagePullSecrets }}
 {{- toYaml .Values.imagePullSecrets | indent 2 }}
 {{- else -}}
-{{- toYaml list "" | indent 2 }}
+{{- toYaml (list "") | indent 2 }}
 {{- end }}
 {{- end }}
 
@@ -227,13 +227,16 @@ Defaults to given value, then the insightsController value, then the top level v
 */}}
 {{- define "cloudzero-agent.initScrapeJob.imagePullSecrets" -}}
 {{- if .Values.initScrapeJob.imagePullSecrets -}}
-{{- toYaml .Values.initScrapeJob.imagePullSecrets | indent 2 }}
+imagePullSecrets:
+{{ toYaml .Values.initScrapeJob.imagePullSecrets | indent 2 }}
 {{- else if .Values.insightsController.server.imagePullSecrets -}}
-{{- toYaml .Values.insightsController.server.imagePullSecrets | indent 2 }}
+imagePullSecrets:
+{{ toYaml .Values.insightsController.server.imagePullSecrets | indent 2 }}
 {{- else if .Values.imagePullSecrets }}
-{{- toYaml .Values.imagePullSecrets | indent 2 }}
+imagePullSecrets:
+{{ toYaml .Values.imagePullSecrets | indent 2 }}
 {{- else -}}
-{{- toYaml list "" | indent 2 }}
+{{- "imagePullSecrets: []" | indent 2 }}
 {{- end }}
 {{- end }}
 
@@ -243,14 +246,33 @@ Defaults to given value, then the insightsController value, then the top level v
 */}}
 {{- define "cloudzero-agent.initCertJob.imagePullSecrets" -}}
 {{- if .Values.initCertJob.imagePullSecrets -}}
-{{- toYaml .Values.initCertJob.imagePullSecrets | indent 2 }}
+imagePullSecrets:
+{{ toYaml .Values.initCertJob.imagePullSecrets | indent 2 }}
 {{- else if .Values.insightsController.server.imagePullSecrets -}}
-{{- toYaml .Values.insightsController.server.imagePullSecrets | indent 2 }}
-{{- else if .Values.imagePullSecrets }}
-{{- toYaml .Values.imagePullSecrets | indent 2 }}
+imagePullSecrets:
+{{ toYaml .Values.insightsController.server.imagePullSecrets | indent 2 }}
+{{- else if .Values.imagePullSecrets -}}
+imagePullSecrets:
+{{ toYaml .Values.imagePullSecrets | indent 2 }}
 {{- else -}}
-{{- toYaml list "" | indent 2 }}
+{{- "imagePullSecrets: []" | indent 2 }}
 {{- end }}
+{{- end }}
+
+
+{{/*
+Get the full container image reference for the init scrape job pod
+*/}}
+{{- define "cloudzero-agent.initScrapeJob.imageReference" -}}
+{{- $repository := .Values.insightsController.server.image.repository -}}
+{{ $tag := .Values.insightsController.server.image.tag -}}
+{{- if and .Values.initScrapeJob.image .Values.initScrapeJob.image.repository -}}
+{{- $repository = .Values.initScrapeJob.image.repository }}
+{{- end }}
+{{- if and .Values.initScrapeJob.image .Values.initScrapeJob.image.tag -}}
+{{- $tag = .Values.initScrapeJob.image.tag -}}
+{{- end }}
+{{- printf "%s:%s" $repository $tag }}
 {{- end }}
 
 {{/*

--- a/charts/cloudzero-agent/templates/_helpers.tpl
+++ b/charts/cloudzero-agent/templates/_helpers.tpl
@@ -23,6 +23,16 @@ Create chart name and version as used by the chart label.
 {{- end}}
 
 {{/*
+imagePullSecrets for the agent server
+*/}}
+{{- define "cloudzero-agent.server.imagePullSecrets" -}}
+{{- if .Values.imagePullSecrets -}}
+imagePullSecrets:
+{{ toYaml .Values.imagePullSecrets | indent 2 -}}
+{{- end }}
+{{- end }}
+
+{{/*
 Name for the validating webhook
 */}}
 {{- define "cloudzero-agent.validatingWebhookName" -}}
@@ -198,6 +208,50 @@ app.kubernetes.io/component: {{ include "cloudzero-agent.initCertJobName" . }}
 {{ include "cloudzero-agent.common.matchLabels" . }}
 {{- end -}}
 
+{{/*
+imagePullSecrets for the insights controller webhook server
+*/}}
+{{- define "cloudzero-agent.insightsController.server.imagePullSecrets" -}}
+{{- if .Values.insightsController.server.imagePullSecrets -}}
+{{- toYaml .Values.imagePullSecrets | indent 2 }}
+{{- else if .Values.imagePullSecrets }}
+{{- toYaml .Values.imagePullSecrets | indent 2 }}
+{{- else -}}
+{{- toYaml list "" | indent 2 }}
+{{- end }}
+{{- end }}
+
+{{/*
+imagePullSecrets for the insights controller init scrape job.
+Defaults to given value, then the insightsController value, then the top level value
+*/}}
+{{- define "cloudzero-agent.initScrapeJob.imagePullSecrets" -}}
+{{- if .Values.initScrapeJob.imagePullSecrets -}}
+{{- toYaml .Values.initScrapeJob.imagePullSecrets | indent 2 }}
+{{- else if .Values.insightsController.server.imagePullSecrets -}}
+{{- toYaml .Values.imagePullSecrets | indent 2 }}
+{{- else if .Values.imagePullSecrets }}
+{{- toYaml .Values.imagePullSecrets | indent 2 }}
+{{- else -}}
+{{- toYaml list "" | indent 2 }}
+{{- end }}
+{{- end }}
+
+{{/*
+imagePullSecrets for the insights controller init cert job.
+Defaults to given value, then the insightsController value, then the top level value
+*/}}
+{{- define "cloudzero-agent.initCertJob.imagePullSecrets" -}}
+{{- if .Values.initCertJob.imagePullSecrets -}}
+{{- toYaml .Values.initCertJob.imagePullSecrets | indent 2 }}
+{{- else if .Values.insightsController.server.imagePullSecrets -}}
+{{- toYaml .Values.imagePullSecrets | indent 2 }}
+{{- else if .Values.imagePullSecrets }}
+{{- toYaml .Values.imagePullSecrets | indent 2 }}
+{{- else -}}
+{{- toYaml list "" | indent 2 }}
+{{- end }}
+{{- end }}
 
 {{/*
 Service selector labels

--- a/charts/cloudzero-agent/templates/_helpers.tpl
+++ b/charts/cloudzero-agent/templates/_helpers.tpl
@@ -235,8 +235,6 @@ imagePullSecrets:
 {{- else if .Values.imagePullSecrets }}
 imagePullSecrets:
 {{ toYaml .Values.imagePullSecrets | indent 2 }}
-{{- else -}}
-{{- "imagePullSecrets: []" | indent 2 }}
 {{- end }}
 {{- end }}
 
@@ -254,8 +252,6 @@ imagePullSecrets:
 {{- else if .Values.imagePullSecrets -}}
 imagePullSecrets:
 {{ toYaml .Values.imagePullSecrets | indent 2 }}
-{{- else -}}
-{{- "imagePullSecrets: []" | indent 2 }}
 {{- end }}
 {{- end }}
 

--- a/charts/cloudzero-agent/templates/_helpers.tpl
+++ b/charts/cloudzero-agent/templates/_helpers.tpl
@@ -213,11 +213,11 @@ imagePullSecrets for the insights controller webhook server
 */}}
 {{- define "cloudzero-agent.insightsController.server.imagePullSecrets" -}}
 {{- if .Values.insightsController.server.imagePullSecrets -}}
-{{- toYaml .Values.insightsController.server.imagePullSecrets | indent 2 }}
+imagePullSecrets:
+{{ toYaml .Values.insightsController.server.imagePullSecrets | indent 2 }}
 {{- else if .Values.imagePullSecrets }}
-{{- toYaml .Values.imagePullSecrets | indent 2 }}
-{{- else -}}
-{{- toYaml (list "") | indent 2 }}
+imagePullSecrets:
+{{ toYaml .Values.imagePullSecrets | indent 2 }}
 {{- end }}
 {{- end }}
 

--- a/charts/cloudzero-agent/templates/_helpers.tpl
+++ b/charts/cloudzero-agent/templates/_helpers.tpl
@@ -213,7 +213,7 @@ imagePullSecrets for the insights controller webhook server
 */}}
 {{- define "cloudzero-agent.insightsController.server.imagePullSecrets" -}}
 {{- if .Values.insightsController.server.imagePullSecrets -}}
-{{- toYaml .Values.imagePullSecrets | indent 2 }}
+{{- toYaml .Values.insightsController.server.imagePullSecrets | indent 2 }}
 {{- else if .Values.imagePullSecrets }}
 {{- toYaml .Values.imagePullSecrets | indent 2 }}
 {{- else -}}
@@ -229,7 +229,7 @@ Defaults to given value, then the insightsController value, then the top level v
 {{- if .Values.initScrapeJob.imagePullSecrets -}}
 {{- toYaml .Values.initScrapeJob.imagePullSecrets | indent 2 }}
 {{- else if .Values.insightsController.server.imagePullSecrets -}}
-{{- toYaml .Values.imagePullSecrets | indent 2 }}
+{{- toYaml .Values.insightsController.server.imagePullSecrets | indent 2 }}
 {{- else if .Values.imagePullSecrets }}
 {{- toYaml .Values.imagePullSecrets | indent 2 }}
 {{- else -}}
@@ -245,7 +245,7 @@ Defaults to given value, then the insightsController value, then the top level v
 {{- if .Values.initCertJob.imagePullSecrets -}}
 {{- toYaml .Values.initCertJob.imagePullSecrets | indent 2 }}
 {{- else if .Values.insightsController.server.imagePullSecrets -}}
-{{- toYaml .Values.imagePullSecrets | indent 2 }}
+{{- toYaml .Values.insightsController.server.imagePullSecrets | indent 2 }}
 {{- else if .Values.imagePullSecrets }}
 {{- toYaml .Values.imagePullSecrets | indent 2 }}
 {{- else -}}

--- a/charts/cloudzero-agent/templates/deploy.yaml
+++ b/charts/cloudzero-agent/templates/deploy.yaml
@@ -144,10 +144,7 @@ spec:
         runAsGroup: 65534
         fsGroup: 65534
       dnsPolicy: ClusterFirst
-    {{- if .Values.imagePullSecrets }}
-      imagePullSecrets:
-{{ toYaml .Values.imagePullSecrets | indent 8 }}
-    {{- end }}
+      {{- include "cloudzero-agent.server.imagePullSecrets" . | nindent 6 -}}
     {{- if .Values.server.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.server.nodeSelector | indent 8 }}

--- a/charts/cloudzero-agent/templates/init-job.yaml
+++ b/charts/cloudzero-agent/templates/init-job.yaml
@@ -17,9 +17,11 @@ spec:
     spec:
       serviceAccountName: {{ include "cloudzero-agent.serviceAccountName" . }}
       restartPolicy: OnFailure
+      imagePullSecrets:
+      {{- include  "cloudzero-agent.initScrapeJob.imagePullSecrets" . | nindent 6 }}
       containers:
         - name: init-scrape
-          image: "{{ .Values.insightsController.server.image.repository }}:{{ .Values.insightsController.server.image.tag | default .Chart.AppVersion }}"
+          image: "{{ default .Values.insightsController.server.image.repository .Values.initScrapeJob.image.repository }}:{{ .Values.initScrapeJob.image.tag | default .Values.insightsController.server.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.insightsController.server.image.pullPolicy }}
           command:
             - /app/controller
@@ -93,6 +95,7 @@ spec:
     spec:
       serviceAccountName: {{ include "cloudzero-agent.serviceAccountName" . }}
       restartPolicy: Never
+      imagePullSecrets:
       containers:
         - name: init-cert
           image: {{ .Values.initCertJob.image.repository }}:{{ .Values.initCertJob.image.tag }}

--- a/charts/cloudzero-agent/templates/init-job.yaml
+++ b/charts/cloudzero-agent/templates/init-job.yaml
@@ -17,11 +17,10 @@ spec:
     spec:
       serviceAccountName: {{ include "cloudzero-agent.serviceAccountName" . }}
       restartPolicy: OnFailure
-      imagePullSecrets:
       {{- include  "cloudzero-agent.initScrapeJob.imagePullSecrets" . | nindent 6 }}
       containers:
         - name: init-scrape
-          image: "{{ default .Values.insightsController.server.image.repository .Values.initScrapeJob.image.repository }}:{{ .Values.initScrapeJob.image.tag | default .Values.insightsController.server.image.tag | default .Chart.AppVersion }}"
+          image: "{{ include  "cloudzero-agent.initScrapeJob.imageReference" . }}"
           imagePullPolicy: {{ .Values.insightsController.server.image.pullPolicy }}
           command:
             - /app/controller
@@ -95,7 +94,6 @@ spec:
     spec:
       serviceAccountName: {{ include "cloudzero-agent.serviceAccountName" . }}
       restartPolicy: Never
-      imagePullSecrets:
       {{- include  "cloudzero-agent.initCertJob.imagePullSecrets" . | nindent 6 }}
       containers:
         - name: init-cert

--- a/charts/cloudzero-agent/templates/init-job.yaml
+++ b/charts/cloudzero-agent/templates/init-job.yaml
@@ -96,6 +96,7 @@ spec:
       serviceAccountName: {{ include "cloudzero-agent.serviceAccountName" . }}
       restartPolicy: Never
       imagePullSecrets:
+      {{- include  "cloudzero-agent.initCertJob.imagePullSecrets" . | nindent 6 }}
       containers:
         - name: init-cert
           image: {{ .Values.initCertJob.image.repository }}:{{ .Values.initCertJob.image.tag }}

--- a/charts/cloudzero-agent/templates/insights-deploy.yaml
+++ b/charts/cloudzero-agent/templates/insights-deploy.yaml
@@ -28,10 +28,8 @@ spec:
         {{- end }}
     spec:
       serviceAccountName: {{ include "cloudzero-agent.serviceAccountName" . }}
-      {{- with .Values.insightsController.server.imagePullSecrets }}
       imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+      {{- include "cloudzero-agent.insightsController.server.imagePullSecrets" . | nindent 6 }}
       securityContext:
         runAsUser: 65534
         runAsNonRoot: true

--- a/charts/cloudzero-agent/templates/insights-deploy.yaml
+++ b/charts/cloudzero-agent/templates/insights-deploy.yaml
@@ -28,7 +28,6 @@ spec:
         {{- end }}
     spec:
       serviceAccountName: {{ include "cloudzero-agent.serviceAccountName" . }}
-      imagePullSecrets:
       {{- include "cloudzero-agent.insightsController.server.imagePullSecrets" . | nindent 6 }}
       securityContext:
         runAsUser: 65534

--- a/charts/cloudzero-agent/values.yaml
+++ b/charts/cloudzero-agent/values.yaml
@@ -219,6 +219,8 @@ insightsController:
   server:
     name: webhook-server
     replicaCount: 3
+    # -- Uncomment to use a specific imagePullSecrets; otherwise, the default top level imagePullSecrets is used.
+    # imagePullSecrets: []
     image:
       repository: ghcr.io/cloudzero/cloudzero-insights-controller/cloudzero-insights-controller
       tag: 0.1.1
@@ -242,7 +244,6 @@ insightsController:
   nodeSelector: {}
   tolerations: []
   affinity: {}
-  imagePullSecrets: []
   podAnnotations: {}
   podLabels: {}
   service:

--- a/charts/cloudzero-agent/values.yaml
+++ b/charts/cloudzero-agent/values.yaml
@@ -81,10 +81,18 @@ serverConfig:
   containerSecretFileName: value
 
 initScrapeJob:
+  # -- By default, all image settings use those set in insightsController.server. Optionally use the below to override. This should not be common.
+  # imagePullSecrets: []
+  # image:
+  #   repository: ghcr.io/cloudzero/cloudzero-insights-controller/cloudzero-insights-controller
+  #   tag: 0.1.1
+  #   pullPolicy: Always
   enabled: true
 
 initCertJob:
   enabled: true
+  # -- Defaults to the same setting as the insightsController.server if set, otherwise left empty.
+  imagePullSecrets: []
   image:
     repository: bitnami/kubectl
     pullPolicy: Always

--- a/charts/cloudzero-agent/values.yaml
+++ b/charts/cloudzero-agent/values.yaml
@@ -92,7 +92,7 @@ initScrapeJob:
 initCertJob:
   enabled: true
   # -- Defaults to the same setting as the insightsController.server if set, otherwise left empty.
-  imagePullSecrets: []
+  # imagePullSecrets: []
   image:
     repository: bitnami/kubectl
     pullPolicy: Always


### PR DESCRIPTION
### Description

the init-cert job doesn't allow imagePullSecrets to be set. this fixes that, and also adds sensible default for all imagepullsecrets

### Testing

**1. with only top level `imagePullSecrets` set, all resources should use that setting:**
given:
```yaml
imagePullSecrets:
  - name: foobar
```
result:

```
helm template cloudzero-agent-with-ui ./ -f ~/dmepham/testing/danm-cluster.yaml | grep imagePullSecrets -A 1
      imagePullSecrets:
        - name: foobar
--
      imagePullSecrets:
        - name: foobar
--
      imagePullSecrets:
        - name: foobar
--
      imagePullSecrets:
        - name: foobar
```

**2. multiple secrets can be given**
given:
```yaml
imagePullSecrets:
  - name: foobar
  - name: batbaz
```
result:
```console
helm template cloudzero-agent-with-ui ./ -f ~/dmepham/testing/danm-cluster.yaml | grep imagePullSecrets -A 2
      imagePullSecrets:
        - name: foobar
        - name: batbaz
--
      imagePullSecrets:
        - name: foobar
        - name: batbaz
--
      imagePullSecrets:
        - name: foobar
        - name: batbaz
--
      imagePullSecrets:
        - name: foobar
        - name: batbaz
```

** 3. init jobs should be able to be individually set**
given 
```yaml
imagePullSecrets:
  - name: foobar
initScrapeJob:
  imagePullSecrets:
  - batbaz
initCertJob:
  imagePullSecrets:
  - cert-batbaz
```
results:
```console
helm template cloudzero-agent-with-ui ./ -f ~/dmepham/testing/danm-cluster.yaml | grep imagePullSecrets -A 1
      imagePullSecrets:
        - name: foobar
--
      imagePullSecrets:
        - name: foobar
--
      imagePullSecrets:
        - batbaz
--
      imagePullSecrets:
        - cert-batbaz
```

**4. insightController default is used if not set explicitly**
given
```yaml
imagePullSecrets:
  - name: foobar
insightsController:
  server:
    imagePullSecrets:
    - name: insights-controller-secret
```
results:
```console
helm template cloudzero-agent-with-ui ./ -f ~/dmepham/testing/danm-cluster.yaml | grep imagePullSecrets -A 1
      imagePullSecrets:
        - name: foobar
--
      imagePullSecrets:
        - name: insights-controller-secret
--
      imagePullSecrets:
        - name: insights-controller-secret
--
      imagePullSecrets:
        - name: insights-controller-secret
```

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`