### PR TITLE
CP-24792: allow more configurable settings, increase default remote write timeout

### DIFF
--- a/charts/cloudzero-agent/docs/releases/1.0.0-beta-9.md
+++ b/charts/cloudzero-agent/docs/releases/1.0.0-beta-9.md
@@ -1,0 +1,13 @@
+## [Release 1.0.0-beta-9](https://github.com/Cloudzero/cloudzero-agent/compare/v0.0.28...v1.0.0-beta-9) (2025-01-15)
+
+This release adds the ability to set the log level via the `insightsController.server.logging.level` field. Additionally, the interval in which data is written to the CloudZero platoform and the timeout for writing data are configurable via `insightsController.server.send_interval` and `insightsController.server.send_timeout`, respectively. The default timeout is increased from `10s` to `1m`.
+
+### Upgrade Steps
+Upgrade using the following command:
+```console
+helm upgrade --install <RELEASE_NAME> cloudzero-beta/cloudzero-agent -n <NAMESPACE> --create-namespace -f configuration.example.yaml --version 1.0.0-beta-9
+```
+
+### Improvements
+* **More Configurable Server Settings:** The log level, remote write interval, and remote write timeout are now configurable in the chart values. See the `insightsController.server` section in the `values.yaml` for more details.
+* **Default Setting for Send Timeout:** The default remote write timeout is increased to `1m`, which allows for backfilling data from larger clusters.

--- a/charts/cloudzero-agent/docs/releases/1.0.0-beta-9.md
+++ b/charts/cloudzero-agent/docs/releases/1.0.0-beta-9.md
@@ -1,6 +1,6 @@
 ## [Release 1.0.0-beta-9](https://github.com/Cloudzero/cloudzero-agent/compare/v0.0.28...v1.0.0-beta-9) (2025-01-15)
 
-This release adds the ability to set the log level via the `insightsController.server.logging.level` field. Additionally, the interval in which data is written to the CloudZero platoform and the timeout for writing data are configurable via `insightsController.server.send_interval` and `insightsController.server.send_timeout`, respectively. The default timeout is increased from `10s` to `1m`.
+This release adds the ability to set the log level via the `insightsController.server.logging.level` field. Additionally, the interval in which data is written to the CloudZero platform and the timeout for writing data are configurable via `insightsController.server.send_interval` and `insightsController.server.send_timeout`, respectively. The default timeout is increased from `10s` to `1m`.
 
 ### Upgrade Steps
 Upgrade using the following command:

--- a/charts/cloudzero-agent/templates/cm.yaml
+++ b/charts/cloudzero-agent/templates/cm.yaml
@@ -186,10 +186,12 @@ data:
     region: {{ .Values.region }}
     cluster_name: {{ .Values.clusterName }}
     host: {{ .Values.host }}
+    logging:
+      level: {{ .Values.insightsController.server.logging.level }}
     remote_write:
-      send_interval: 1m
+      send_interval: {{ .Values.insightsController.server.send_interval }}
       max_bytes_per_send: 500000
-      send_timeout: 10s
+      send_timeout: {{ .Values.insightsController.server.send_timeout }}
       max_retries: 3
     k8s_client:
       timeout: 30s

--- a/charts/cloudzero-agent/values.yaml
+++ b/charts/cloudzero-agent/values.yaml
@@ -228,7 +228,11 @@ insightsController:
     port: 8443
     read_timeout: 10s
     write_timeout: 10s
+    send_timeout: 1m
+    send_interval: 1m
     idle_timeout: 120s
+    logging:
+      level: info
     healthCheck:
       enabled: true
       path: /healthz


### PR DESCRIPTION
### Description

- allows the user to configure log level
- increases the default remote write timeout to 1m to allow for large clusters to be backfilled by default

### Testing

with the following settings:
```yaml
insightsController:
  server:
    logging:
      level: debug
    send_interval: 10s
    send_timeout: 2m
```
results
```console
kg cm cloudzero-agent-with-ui-webhook-configuration -o yaml | grep -E 'send_interval|send_timeout|level'
      level: debug
      send_interval: 10s
      send_timeout: 2m
```
- debug logs in the webhook server pods (including scrape pod) are enabled
- send timeout is shown to be 2m during the scrape job

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`