### PR TITLE
CP-23129: add Prometheus scrape job to scrape metrics from itself

### DIFF
--- a/charts/cloudzero-agent/templates/_helpers.tpl
+++ b/charts/cloudzero-agent/templates/_helpers.tpl
@@ -150,7 +150,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 Combine metric lists
 */}}
 {{- define "cloudzero-agent.combineMetrics" -}}
-{{- $total := concat .Values.kubeMetrics .Values.containerMetrics .Values.insightsMetrics -}}
+{{- $total := concat .Values.kubeMetrics .Values.containerMetrics .Values.insightsMetrics .Values.prometheusMetrics -}}
 {{- $result := join "|" $total -}}
 {{- $result -}}
 {{- end -}}

--- a/charts/cloudzero-agent/templates/cm.yaml
+++ b/charts/cloudzero-agent/templates/cm.yaml
@@ -137,6 +137,10 @@ data:
           - source_labels: [__meta_kubernetes_endpoints_name]
             action: keep
             regex: {{ include "cloudzero-agent.insightsController.server.webhookFullname" . }}-svc
+        metric_relabel_configs:
+          - source_labels: [__name__]
+            regex: "^({{ join "|" .Values.insightsMetrics }})$"
+            action: keep
       {{- end }}
       {{- if .Values.prometheusConfig.scrapeJobs.additionalScrapeJobs -}}
       {{ toYaml .Values.prometheusConfig.scrapeJobs.additionalScrapeJobs | toString | nindent 6 }}

--- a/charts/cloudzero-agent/templates/cm.yaml
+++ b/charts/cloudzero-agent/templates/cm.yaml
@@ -21,7 +21,7 @@ data:
       - job_name: static-kube-state-metrics
         honor_timestamps: true
         track_timestamps_staleness: false
-        scrape_interval: 1m
+        scrape_interval: {{ .Values.prometheusConfig.scrapeJobs.kubeStateMetrics.scrapeInterval }}
         scrape_timeout: 10s
         scrape_protocols:
         - OpenMetricsText1.0.0
@@ -140,6 +140,18 @@ data:
         metric_relabel_configs:
           - source_labels: [__name__]
             regex: "^({{ join "|" .Values.insightsMetrics }})$"
+            action: keep
+      {{- end }}
+      {{- if .Values.prometheusConfig.scrapeJobs.prometheus.enabled }}
+      - job_name: static-prometheus
+        scrape_interval: {{ .Values.prometheusConfig.scrapeJobs.prometheus.scrapeInterval }}
+        static_configs:
+          - targets:
+              - localhost:9090
+        metrics_path: /metrics
+        metric_relabel_configs:
+          - source_labels: [__name__]
+            regex: "^({{ join "|" .Values.prometheusMetrics }})$"
             action: keep
       {{- end }}
       {{- if .Values.prometheusConfig.scrapeJobs.additionalScrapeJobs -}}

--- a/charts/cloudzero-agent/templates/deploy.yaml
+++ b/charts/cloudzero-agent/templates/deploy.yaml
@@ -95,7 +95,10 @@ spec:
                   - -c
                   - /check/app/cloudzero-agent-validator d pre-stop -f /check/app/config/validator.yml
           args:
-        {{ toYaml .Values.server.args | nindent 12}}
+            {{ toYaml .Values.server.args | nindent 12}}
+            {{- if .Values.server.agentMode }}
+            - --enable-feature=agent
+            {{- end }}
           ports:
             - containerPort: 9090
           readinessProbe:

--- a/charts/cloudzero-agent/values.yaml
+++ b/charts/cloudzero-agent/values.yaml
@@ -154,12 +154,12 @@ server:
       memory: 1024Mi
   deploymentAnnotations: {}
   podAnnotations: {}
+  agentMode: true
   args:
   - --config.file=/etc/config/prometheus/configmaps/prometheus.yml
   - --web.enable-lifecycle
   - --web.console.libraries=/etc/prometheus/console_libraries
   - --web.console.templates=/etc/prometheus/consoles
-  - --enable-feature=agent
   persistentVolume:
     existingClaim: ""
     enabled: false

--- a/charts/cloudzero-agent/values.yaml
+++ b/charts/cloudzero-agent/values.yaml
@@ -51,8 +51,72 @@ insightsMetrics:
   - remote_write_db_failures_total
   - http_requests_total
   - storage_write_failure_total
-
-
+prometheusMetrics:
+  - go_memstats_alloc_bytes
+  - go_memstats_heap_alloc_bytes
+  - go_memstats_heap_idle_bytes
+  - go_memstats_heap_inuse_bytes
+  - go_memstats_heap_objects
+  - go_memstats_last_gc_time_seconds
+  - go_memstats_alloc_bytes
+  - go_memstats_stack_inuse_bytes
+  - go_goroutines
+  - process_cpu_seconds_total
+  - process_max_fds
+  - process_open_fds
+  - process_resident_memory_bytes
+  - process_start_time_seconds
+  - process_virtual_memory_bytes
+  - process_virtual_memory_max_bytes
+  - prometheus_agent_corruptions_total
+  - prometheus_api_remote_read_queries
+  - prometheus_http_requests_total
+  - prometheus_notifications_alertmanagers_discovered
+  - prometheus_notifications_dropped_total
+  - prometheus_remote_storage_bytes_total
+  - prometheus_remote_storage_histograms_failed_total
+  - prometheus_remote_storage_histograms_total
+  - prometheus_remote_storage_metadata_bytes_total
+  - prometheus_remote_storage_metadata_failed_total
+  - prometheus_remote_storage_metadata_retried_total
+  - prometheus_remote_storage_metadata_total
+  - prometheus_remote_storage_samples_dropped_total
+  - prometheus_remote_storage_samples_failed_total
+  - prometheus_remote_storage_samples_in_total
+  - prometheus_remote_storage_samples_total
+  - prometheus_remote_storage_shard_capacity
+  - prometheus_remote_storage_shards
+  - prometheus_remote_storage_shards_desired
+  - prometheus_remote_storage_shards_max
+  - prometheus_remote_storage_shards_min
+  - prometheus_sd_azure_cache_hit_total
+  - prometheus_sd_azure_failures_total
+  - prometheus_sd_discovered_targets
+  - prometheus_sd_dns_lookup_failures_total
+  - prometheus_sd_failed_configs
+  - prometheus_sd_file_read_errors_total
+  - prometheus_sd_file_scan_duration_seconds
+  - prometheus_sd_file_watcher_errors_total
+  - prometheus_sd_http_failures_total
+  - prometheus_sd_kubernetes_events_total
+  - prometheus_sd_kubernetes_http_request_duration_seconds
+  - prometheus_sd_kubernetes_http_request_total
+  - prometheus_sd_kubernetes_workqueue_depth
+  - prometheus_sd_kubernetes_workqueue_items_total
+  - prometheus_sd_kubernetes_workqueue_latency_seconds
+  - prometheus_sd_kubernetes_workqueue_longest_running_processor_seconds
+  - prometheus_sd_kubernetes_workqueue_unfinished_work_seconds
+  - prometheus_sd_kubernetes_workqueue_work_duration_seconds
+  - prometheus_sd_received_updates_total
+  - prometheus_sd_updates_delayed_total
+  - prometheus_sd_updates_total
+  - prometheus_target_scrape_pool_reloads_failed_total
+  - prometheus_target_scrape_pool_reloads_total
+  - prometheus_target_scrape_pool_sync_total
+  - prometheus_target_scrape_pools_failed_total
+  - prometheus_target_scrape_pools_total
+  - prometheus_target_sync_failed_total
+  - prometheus_target_sync_length_seconds
 # -- Any items added to this array will be added to the metrics that are sent to CloudZero, in addition to the minimal labels that CloudZero requires.
 additionalMetricLabels: []
 
@@ -70,6 +134,10 @@ prometheusConfig:
     cadvisor:
       enabled: true
       scrapeInterval: 120s  # Scrape interval for nodesCadvisor job
+    # -- Enables the prometheus scrape job.
+    prometheus:
+      enabled: true
+      scrapeInterval: 120s  # Scrape interval for prometheus job
     # -- Any items added to this list will be added to the Prometheus scrape configuration.
     additionalScrapeJobs: []
 


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [CloudZero Code of Conduct](https://github.com/cloudzero/template-cloudzero-open-source/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/cloudzero/template-cloudzero-open-source/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

I also switched from a hardcoded value it to using `prometheusConfig.scrapeJobs.kubeStateMetrics.scrapeInterval` for the KSM job scrape_interval. This seems to pretty clearly be the intent of the configuration option, but it was not being used. Notably, this increases the interval from 1m to 2m.

### References

> Include any links supporting this change such as a:
>
> - GitHub Issue/PR number addressed or fixed
> - StackOverflow post
> - Support forum thread
> - Related pull requests/issues from other repos
>
> If there are no references, simply delete this section.

### Testing

> Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
>
> Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.
>
> Also include details of the environment this PR was developed in (language/platform/browser version).

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`