### PR TITLE
CP-24792: add KSM image info for easy identification of images to mirror for private image registries

### DIFF
--- a/charts/cloudzero-agent/README.md
+++ b/charts/cloudzero-agent/README.md
@@ -254,6 +254,18 @@ Next, upgrade the installation to the latest chart version:
 helm upgrade --install <RELEASE_NAME> cloudzero/cloudzero-agent -f configuration.example.yaml
 ```
 
+#### Getting All Image References
+
+A common customization may be to mirror the container images used in this chart into a private registry. To fetch all image references used in this chart, use the following commands:
+
+```console
+CHART_VERSION=1.0.0        # Set this to the chart version for which container image references should be fetched
+CHART_REPO=cloudzero       # Set this to the name of cloudzero helm repository.
+helm template $CHART_REPO/cloudzero-agent --version $CHART_VERSION --set clusterName=foobar --set cloudAccountId=foobar --set region=foobar | grep -i image: | tr -d '"' | sort | uniq | awk '{print $NF}'
+```
+
+This will return the latest image references for that particular chart version.
+
 #### Passing Values to Subcharts
 
 Values can be passed to subcharts like [kube-state-metrics](https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-state-metrics/values.yaml) by adding entries in `values-override.yaml` as per their specifications.

--- a/charts/cloudzero-agent/docs/releases/1.0.0-beta-9.md
+++ b/charts/cloudzero-agent/docs/releases/1.0.0-beta-9.md
@@ -13,4 +13,4 @@ helm upgrade --install <RELEASE_NAME> cloudzero-beta/cloudzero-agent -n <NAMESPA
 ### Improvements
 * **More Configurable Server Settings:** The log level, remote write interval, and remote write timeout are now configurable in the chart values. See the `insightsController.server` section in the `values.yaml` for more details.
 * **Default Setting for Send Timeout:** The default remote write timeout is increased to `1m`, which allows for backfilling data from larger clusters.
-* **Container Image Information Added:** The values passed to the internal `kube-state-metrics` subchart now explicilty sets the container image registry, repository, and tag information for the purposes of documentation.
+* **Container Image Information Added:** The values passed to the internal `kube-state-metrics` subchart now explicilty set the container image registry, repository, and tag information for the purposes of documentation.

--- a/charts/cloudzero-agent/docs/releases/1.0.0-beta-9.md
+++ b/charts/cloudzero-agent/docs/releases/1.0.0-beta-9.md
@@ -2,7 +2,7 @@
 
 This release adds the ability to set the log level via the `insightsController.server.logging.level` field. Additionally, the interval in which data is written to the CloudZero platform and the timeout for writing data are configurable via `insightsController.server.send_interval` and `insightsController.server.send_timeout`, respectively. The default timeout is increased from `10s` to `1m`.
 
-The `kube-state-metrics` subchart section now explicilty includes container image information. This introduces no funcitonal changes; it is intended to make it clearer to the user which images will be used and from where they will be pulled.
+The `kube-state-metrics` subchart section now explicitly includes container image information. This introduces no functional changes; it is intended to make it clearer to the user which images will be used and from where they will be pulled.
 
 ### Upgrade Steps
 Upgrade using the following command:

--- a/charts/cloudzero-agent/docs/releases/1.0.0-beta-9.md
+++ b/charts/cloudzero-agent/docs/releases/1.0.0-beta-9.md
@@ -2,6 +2,8 @@
 
 This release adds the ability to set the log level via the `insightsController.server.logging.level` field. Additionally, the interval in which data is written to the CloudZero platform and the timeout for writing data are configurable via `insightsController.server.send_interval` and `insightsController.server.send_timeout`, respectively. The default timeout is increased from `10s` to `1m`.
 
+The `kube-state-metrics` subchart section now explicilty includes container image information. This introduces no funcitonal changes; it is intended to make it clearer to the user which images will be used and from where they are pulled.
+
 ### Upgrade Steps
 Upgrade using the following command:
 ```console
@@ -11,3 +13,4 @@ helm upgrade --install <RELEASE_NAME> cloudzero-beta/cloudzero-agent -n <NAMESPA
 ### Improvements
 * **More Configurable Server Settings:** The log level, remote write interval, and remote write timeout are now configurable in the chart values. See the `insightsController.server` section in the `values.yaml` for more details.
 * **Default Setting for Send Timeout:** The default remote write timeout is increased to `1m`, which allows for backfilling data from larger clusters.
+* **Container Image Information Added:** The values passed to the internal `kube-state-metrics` subchart now explicilty sets the container image registry, repository, and tag information for the purposes of documentation.

--- a/charts/cloudzero-agent/docs/releases/1.0.0-beta-9.md
+++ b/charts/cloudzero-agent/docs/releases/1.0.0-beta-9.md
@@ -13,4 +13,4 @@ helm upgrade --install <RELEASE_NAME> cloudzero-beta/cloudzero-agent -n <NAMESPA
 ### Improvements
 * **More Configurable Server Settings:** The log level, remote write interval, and remote write timeout are now configurable in the chart values. See the `insightsController.server` section in the `values.yaml` for more details.
 * **Default Setting for Send Timeout:** The default remote write timeout is increased to `1m`, which allows for backfilling data from larger clusters.
-* **Container Image Information Added:** The values passed to the internal `kube-state-metrics` subchart now explicilty set the container image registry, repository, and tag information for the purposes of documentation.
+* **Container Image Information Added:** The values passed to the internal `kube-state-metrics` subchart now explicitly set the container image registry, repository, and tag information for the purposes of documentation.

--- a/charts/cloudzero-agent/docs/releases/1.0.0-beta-9.md
+++ b/charts/cloudzero-agent/docs/releases/1.0.0-beta-9.md
@@ -2,7 +2,7 @@
 
 This release adds the ability to set the log level via the `insightsController.server.logging.level` field. Additionally, the interval in which data is written to the CloudZero platform and the timeout for writing data are configurable via `insightsController.server.send_interval` and `insightsController.server.send_timeout`, respectively. The default timeout is increased from `10s` to `1m`.
 
-The `kube-state-metrics` subchart section now explicilty includes container image information. This introduces no funcitonal changes; it is intended to make it clearer to the user which images will be used and from where they are pulled.
+The `kube-state-metrics` subchart section now explicilty includes container image information. This introduces no funcitonal changes; it is intended to make it clearer to the user which images will be used and from where they will be pulled.
 
 ### Upgrade Steps
 Upgrade using the following command:

--- a/charts/cloudzero-agent/values.yaml
+++ b/charts/cloudzero-agent/values.yaml
@@ -100,6 +100,10 @@ initCertJob:
 
 kubeStateMetrics:
   enabled: true
+  image:
+    registry: registry.k8s.io
+    repository: kube-state-metrics/kube-state-metrics
+    tag: "v2.10.1"
   nameOverride: "cloudzero-state-metrics"
   # Disable CloudZero KSM as a Scrape Target since the service endpoint is explicity defined
   # by the Validators config file.


### PR DESCRIPTION
### Description

many users will be using a private image repo, and will need to get the images to mirror to their private image repo. adding the image information to the KSM subchart section will make this easier while not changing funcitonality

### Testing
Before change:
```console
kg po cloudzero-agent-with-ui-cloudzero-state-metrics-569f756d86zcszc -o yaml | grep -i image
    image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.10.1
```
After change:
```console
kg pod cloudzero-agent-with-ui-cloudzero-state-metrics-569f756d86m85jj -o yaml | grep -i image
    image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.10.1
```
Note that there is no change in image reference


### Checklist

- [ ] I have added documentation for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`