### PR TITLE
CP-24833: template KSM service address using the release name

### DIFF
--- a/charts/cloudzero-agent/docs/releases/1.0.0-beta-9.md
+++ b/charts/cloudzero-agent/docs/releases/1.0.0-beta-9.md
@@ -10,6 +10,9 @@ Upgrade using the following command:
 helm upgrade --install <RELEASE_NAME> cloudzero-beta/cloudzero-agent -n <NAMESPACE> --create-namespace -f configuration.example.yaml --version 1.0.0-beta-9
 ```
 
+### Bug Fixes
+* **KSM Address:** Fixes an issue in which the internal `kube-state-metrics` service address can be templated incorrectly.
+
 ### Improvements
 * **More Configurable Server Settings:** The log level, remote write interval, and remote write timeout are now configurable in the chart values. See the `insightsController.server` section in the `values.yaml` for more details.
 * **Default Setting for Send Timeout:** The default remote write timeout is increased to `1m`, which allows for backfilling data from larger clusters.

--- a/charts/cloudzero-agent/templates/_helpers.tpl
+++ b/charts/cloudzero-agent/templates/_helpers.tpl
@@ -171,7 +171,7 @@ KubeStateMetrics target override
 */}}
 {{- define "cloudzero-agent.kubeStateMetrics.targetOverride" -}}
 {{- if .Values.kubeStateMetrics.enabled -}}
-{{ printf "%s.%s.svc.cluster.local:%d" .Values.kubeStateMetrics.nameOverride .Release.Namespace (int .Values.kubeStateMetrics.service.port) }}
+{{ printf "%s-%s.%s.svc.cluster.local:%d" .Release.Name .Values.kubeStateMetrics.nameOverride .Release.Namespace (int .Values.kubeStateMetrics.service.port) }}
 {{- else -}}
 {{- if not .Values.kubeStateMetrics.targetOverride }}
 {{- required "You must set a targetOverride for kubeStateMetrics" .Values.kubeStateMetrics.targetOverride -}}

--- a/charts/cloudzero-agent/templates/validatorcm.yaml
+++ b/charts/cloudzero-agent/templates/validatorcm.yaml
@@ -33,12 +33,7 @@ data:
       {{- if .Values.validator.serviceEndpoints.kubeStateMetrics }}
       kube_state_metrics_service_endpoint: http://{{ .Values.validator.serviceEndpoints.kubeStateMetrics }}/
       {{- else }}
-      kube_state_metrics_service_endpoint: http://{{ .Values.kubeStateMetrics.nameOverride }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.kubeStateMetrics.service.port }}
-      {{- end }}
-      {{- if .Values.validator.serviceEndpoints.prometheusNodeExporter }}
-      prometheus_node_exporter_service_endpoint: http://{{ .Values.validator.serviceEndpoints.prometheusNodeExporter }}/
-      {{- else }}
-      prometheus_node_exporter_service_endpoint: http://{{- if .Release.Name }}{{.Release.Name}}-{{- end }}prometheus-node-exporter:9100/
+      kube_state_metrics_service_endpoint: http://{{ include "cloudzero-agent.kubeStateMetrics.targetOverride" . }}
       {{- end }}
       executable: /bin/prometheus
       kube_metrics:


### PR DESCRIPTION
### Description

Fixes an issue introduced in a recent beta version where the KSM address will be formed incorrectly if the full name override is not supplied

### Testing

1. testing with no additional settings for KSM shows all required metrics in the prom ui
2. testing with
```yaml
kubeStateMetrics:
  enabled: false
  targetOverride: "indie-ksm-kube-state-metrics.kube-system.svc.cluster.local:8080"
```
 shows all required metrics in the prom ui

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`