### PR TITLE
CP-24815 Fix KSM label allowlist syntax in README

### DIFF
--- a/charts/cloudzero-agent/README.md
+++ b/charts/cloudzero-agent/README.md
@@ -234,7 +234,7 @@ kube-state-metrics:
 
 ⚠️ Important: If you are running an existing `kube-state-metrics` instance, ensure that the labels you want to use are whitelisted. kube-state-metrics version 2.x and above will **_not_** export the `kube_pod_labels` metrics unless they are explicitly allowed. This prevents the use of those labels for cost allocation and other purposes. Make sure you have configured the labels at the appropriate level using the --metric-labels-allowlist parameter:
 
-> eg:  `- --metric-labels-allowlist=namespaces=[*],pods=[*],deployments=[app.kubernetes.io/*,k8s.*]`
+> eg:  `- --metric-labels-allowlist=pods=[*]`
 
 ## Dependencies
 


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [CloudZero Code of Conduct](https://github.com/cloudzero/template-cloudzero-open-source/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/cloudzero/template-cloudzero-open-source/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

This PR fixes the [README](https://github.com/Cloudzero/cloudzero-charts/blob/develop/charts/cloudzero-agent/README.md#exporting-pod-labels) example for allowlisting pod labels. According to the [kube-state-metrics](https://github.com/kubernetes/kube-state-metrics/blob/main/docs/developer/cli-arguments.md) documentation, the syntax used in the example is invalid.

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`