### PR TITLE
[CP-24912] use image tag and chart name in init job name

### DIFF
--- a/charts/cloudzero-agent/templates/_helpers.tpl
+++ b/charts/cloudzero-agent/templates/_helpers.tpl
@@ -351,7 +351,9 @@ Name for the issuer resource
 Name for the job resource
 */}}
 {{- define "cloudzero-agent.initScrapeJobName" -}}
-{{- printf "%s-init-scrape" (include "cloudzero-agent.insightsController.server.webhookFullname" .) }}
+{{- $name := printf "%s-init-scrape-%s" .Release.Name .Chart.Version }}
+{{- $imageRef := splitList ":" (include  "cloudzero-agent.initScrapeJob.imageReference" .) | last }}
+{{- printf "%s-%s" $name ($imageRef | trunc 8) | trunc 63 }}
 {{- end }}
 
 {{/*

--- a/charts/cloudzero-agent/templates/_helpers.tpl
+++ b/charts/cloudzero-agent/templates/_helpers.tpl
@@ -348,12 +348,12 @@ Name for the issuer resource
 {{- end }}
 
 {{/*
-Name for the job resource
+Name for the initScrape job resource
 */}}
 {{- define "cloudzero-agent.initScrapeJobName" -}}
-{{- $name := printf "%s-init-scrape-%s" .Release.Name .Chart.Version }}
+{{- $name := printf "%s-scrape-%s" .Release.Name .Chart.Version }}
 {{- $imageRef := splitList ":" (include  "cloudzero-agent.initScrapeJob.imageReference" .) | last }}
-{{- printf "%s-%s" $name ($imageRef | trunc 8) | trunc 63 }}
+{{- printf "%s-%s" $name ($imageRef | trunc 8) | trunc 63 | replace "." "-" }}
 {{- end }}
 
 {{/*


### PR DESCRIPTION
### Description

**Problem:**
When upgrading and updating the image used in the init scrape job, we can hit issues because the Job image field is immutable. this can be easily fixed by including a reference to the image tag and the chart version in the job name

another benefit is that we re-capture state on every upgrade, which is beneficial if we're adding bugfixes

**Example:**

install a chart:
```console
helm upgrade --install cloudzero-agent-with-ui cloudzero-beta/cloudzero-agent -f override.yaml --version 1.0.0-beta-10

Release "cloudzero-agent-with-ui" does not exist. Installing it now.
NAME: cloudzero-agent-with-ui
LAST DEPLOYED: Thu Jan 23 16:52:56 2025
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
```

then update it to use a new image version. this would most likely happen when we upgrade versions, but I'm forcing the issue here:
```console
 helm upgrade --install cloudzero-agent-with-ui cloudzero-beta/cloudzero-agent -f override.yaml --version 1.0.0-beta-10 --set insightsController.server.image.tag=dev-8ab4ed90ea5f664bd8fb065448891188831fdf85
```
output is:
```console
Error: UPGRADE FAILED: cannot patch "cloudzero-agent-with-ui-webhook-server-init-scrape" with kind Job: Job.batch "cloudzero-agent-with-ui-webhook-server-init-scrape" is invalid: spec.template: Invalid value: core.PodTemplateSpec{ObjectMeta:v1.ObjectMeta{Name:"cloudzero-agent-with-ui-webhook-server-init-scrape", GenerateName:"", Namespace:"default", SelfLink:"", UID:"", ResourceVersion:"", Generation:0, CreationTimestamp:time.Date(1, time.January, 1, 0, 0, 0, 0, time.UTC), DeletionTimestamp:<nil>, DeletionGracePeriodSeconds:(*int64)(nil), Labels:map[string]string{"app.kubernetes.io/component":"c
```
truncated for brevity.

**Solution**
Including the chart and image version in the Job name will ensure that we create new jobs.

### Testing
install the chart
```console
helm upgrade --install cloudzero-agent-with-ui ./ -f override.yaml 
Release "cloudzero-agent-with-ui" does not exist. Installing it now.
NAME: cloudzero-agent-with-ui
LAST DEPLOYED: Thu Jan 23 17:06:09 2025
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
```
Job and Pod are created with a new names: `cloudzero-agent-with-ui-scrape-1-0-0-beta-10-0-1-1` and `cloudzero-agent-with-ui-scrape-1-0-0-beta-10-0-1-1-78fmv`

then, updating with a custom image like before:
```console
helm upgrade --install cloudzero-agent-with-ui ./ -f override.yaml --set insightsController.server.image.tag=dev-8ab4ed90ea5f664bd8fb065448891188831fdf85
Release "cloudzero-agent-with-ui" has been upgraded. Happy Helming!
NAME: cloudzero-agent-with-ui
LAST DEPLOYED: Thu Jan 23 17:07:44 2025
NAMESPACE: default
STATUS: deployed
REVISION: 2
TEST SUITE: None
NOTES:
```
✅ no error

pod name is `cloudzero-agent-with-ui-scrape-1-0-0-beta-10-dev-8ab4-4jt5g` - note the truncated image tag
job name is `cloudzero-agent-with-ui-scrape-1-0-0-beta-10-dev-8ab4`, and the old job is cleaned up


### Checklist

- [ ] I have added documentation for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`