### PR TITLE
[CP-24655] rename "scrape" to "backfill"

### DIFF
--- a/charts/cloudzero-agent/templates/init-job.yaml
+++ b/charts/cloudzero-agent/templates/init-job.yaml
@@ -1,26 +1,27 @@
 {{- if .Values.insightsController.enabled }}
-{{- if .Values.initScrapeJob.enabled }}
+{{ $backFillValues := (include "cloudzero-agent.backFill" . | fromYaml) }}
+{{- if $backFillValues.enabled }}
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ include "cloudzero-agent.initScrapeJobName" . }}
+  name: {{ include "cloudzero-agent.initBackfillJobName" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cloudzero-agent.insightsController.labels" . | nindent 4 }}
 spec:
   template:
     metadata:
-      name: {{ include "cloudzero-agent.initScrapeJobName" . }}
+      name: {{ include "cloudzero-agent.initBackfillJobName" . }}
       namespace: {{ .Release.Namespace }}
       labels:
-        {{- include "cloudzero-agent.insightsController.initScrapeJob.matchLabels" . | nindent 8 }}
+        {{- include "cloudzero-agent.insightsController.initBackfillJob.matchLabels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ include "cloudzero-agent.serviceAccountName" . }}
       restartPolicy: OnFailure
-      {{- include  "cloudzero-agent.initScrapeJob.imagePullSecrets" . | nindent 6 }}
+      {{- include  "cloudzero-agent.initBackfillJob.imagePullSecrets" . | nindent 6 }}
       containers:
         - name: init-scrape
-          image: "{{ include  "cloudzero-agent.initScrapeJob.imageReference" . }}"
+          image: "{{ include  "cloudzero-agent.initBackfillJob.imageReference" . }}"
           imagePullPolicy: {{ .Values.insightsController.server.image.pullPolicy }}
           command:
             - /app/controller

--- a/charts/cloudzero-agent/values.yaml
+++ b/charts/cloudzero-agent/values.yaml
@@ -148,7 +148,8 @@ serverConfig:
   # -- The agent will look for a file with this name to get the CZ API key.
   containerSecretFileName: value
 
-initScrapeJob:
+# -- The following settings are for the init-backfill-job, which is used to backfill data from the cluster to CloudZero.
+initBackfillJob:
   # -- By default, all image settings use those set in insightsController.server. Optionally use the below to override. This should not be common.
   # imagePullSecrets: []
   # image:
@@ -156,6 +157,16 @@ initScrapeJob:
   #   tag: 0.1.1
   #   pullPolicy: Always
   enabled: true
+
+# -- This is a deprecated field that is replaced by initBackfillJob. However, the fields are identical, and initScrapeJob can still be used to configure the backFill/scrape Job.
+# initScrapeJob:
+  # -- By default, all image settings use those set in insightsController.server. Optionally use the below to override. This should not be common.
+  # imagePullSecrets: []
+  # image:
+  #   repository: ghcr.io/cloudzero/cloudzero-insights-controller/cloudzero-insights-controller
+  #   tag: 0.1.1
+  #   pullPolicy: Always
+
 
 initCertJob:
   enabled: true


### PR DESCRIPTION
### Description

"scrape" is a poor name here, since it is an overloaded term in the prometheus world. 

~The downside is that this would be a breaking change for users on the beta-9 through beta-10~

update: `initBackfillJob` is the documented field to use, but `initScrapeJob` can still be used as well. if both exist, `initBackfillJob` is given preference

### Testing

1. validated that `initBackfillJob` and `initScrapeJob` can be used interchangeably and produce the same templated yaml
2. validated precedence rules. given the following input:
```yaml
initScrapeJob:
  image:
    repository: scrape.com/scrape
    tag: 1.2.3
    pullPolicy: Always
  imagePullSecrets:
    - name: foobar
initBackfillJob:
  image:
    repository: backfill.com/backfill
    pullPolicy: Always
```
produces the following:
```yaml
apiVersion: batch/v1
kind: Job
metadata:
  name: cloudzero-agent-with-ui-backfill-1-0-0-beta-10-1-2-3
  namespace: default
  labels:
    app.kubernetes.io/component: webhook-server
    app.kubernetes.io/name: cloudzero-agent
    app.kubernetes.io/instance: cloudzero-agent-with-ui
    app.kubernetes.io/version: v2.50.1
    helm.sh/chart: cloudzero-agent-1.0.0-beta-10
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/part-of: cloudzero-agent
spec:
  template:
    metadata:
      name: cloudzero-agent-with-ui-backfill-1-0-0-beta-10-1-2-3
      namespace: default
      labels:
        app.kubernetes.io/component: cloudzero-agent-with-ui-backfill-1-0-0-beta-10-1-2-3
        app.kubernetes.io/name: cloudzero-agent
        app.kubernetes.io/instance: cloudzero-agent-with-ui
    spec:
      serviceAccountName: cloudzero-agent-with-ui-server
      restartPolicy: OnFailure
      imagePullSecrets:
        - name: foobar
      containers:
        - name: init-scrape
          image: "backfill.com/backfill:1.2.3"
          imagePullPolicy: Always
```
note that:
- image repository is `backfill.com/backfill`, from `initBackfillJob`
- tag is `1.2.3`, from `initScrapeJob`
- imagePullSecrets is `foobar` from `initScrapeJob`

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`