### PR TITLE
CP-25165: removing insights-controller refs in release branch

### DIFF
--- a/.github/workflows/build-and-publish-chart.yml
+++ b/.github/workflows/build-and-publish-chart.yml
@@ -48,28 +48,19 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@v3
 
-      # Step 4: Determine Version
-      - name: Get Github Tag Version
-        id: version
-        uses: flatherskevin/semver-action@v1
-        with:
-          incrementLevel: patch
-          source: tags
-
-      - name: Determine Chart Version
+      # Step 4: Validate and Set Version
+      - name: Validate Input Version
         run: |
-          NEW_VERSION=${{ github.event.inputs.version || steps.version.outputs.nextVersion }}
-          echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_ENV
+          if [[ -z "${{ github.event.inputs.version }}" ]]; then
+            echo "Version input is required."
+            exit 1
+          fi
+          echo "NEW_VERSION=${{ github.event.inputs.version }}" >> $GITHUB_ENV
 
       - name: Update Chart Version
         run: |
           VERSION_LINE=$(awk '/version:/ && !done {print NR; done=1}' charts/cloudzero-agent/Chart.yaml)
           sed -i ''$VERSION_LINE's/.*/version: ${{ env.NEW_VERSION }}/' charts/cloudzero-agent/Chart.yaml
-
-      - name: Update Chart Version for insights-controller
-        run: |
-          VERSION_LINE=$(awk '/version:/ && !done {print NR; done=1}' charts/cloudzero-insights-controller/Chart.yaml)
-          sed -i ''$VERSION_LINE's/.*/version: ${{ env.NEW_VERSION }}/' charts/cloudzero-insights-controller/Chart.yaml
 
       - name: Validate Release Notes are Present
         run: |
@@ -78,22 +69,13 @@ jobs:
             exit 1
           fi
 
-      - name: Build Insights Controller Dependencies
-        run: helm dependency update charts/cloudzero-insights-controller/
-
-      - name: Package Insights Controller Chart
-        run: helm package charts/cloudzero-insights-controller/ --destination .deploy
-
-      - name: Build Cloudzero Agent Dependencies
+      # Step 4: Package and Commit Chart
+      - name: Build Dependencies
         run: helm dependency update charts/cloudzero-agent/
 
-      - name: Package Cloudzero Agent Chart
-        run: helm package charts/cloudzero-agent/ --destination .deploy
-
-      - name: Get Main Changelog Beginning Hash
+      - name: Package Chart
         run: |
-          MAIN_PREV_COMMIT_HASH=$(git rev-parse HEAD)
-          echo "MAIN_PREV_COMMIT_HASH=${MAIN_PREV_COMMIT_HASH}" >> $GITHUB_ENV
+          helm package charts/cloudzero-agent/ --destination .deploy
 
       - name: Commit updated Chart.yaml
         run: |
@@ -104,28 +86,12 @@ jobs:
           echo "COMMIT_HASH=${COMMIT_HASH}" >> $GITHUB_ENV
         continue-on-error: true
 
-      # Step 6: Generate Change Log
-      - name: Generate Change Log
-        id: get_changes
-        run: |
-          FROM=${{ env.MAIN_PREV_COMMIT_HASH }}
-          TO=$(git rev-parse --short HEAD)
-          CHANGES=$(git log ${FROM}..${TO} --oneline)
-          echo "::set-output name=changes::${CHANGES}"
-
       # Step 7: Handle Artifacts and Update Pages
-      - name: Upload Insight Controller Chart as Artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: agent-chart
-          path: .deploy/cloudzero-insights-controller-${{ env.NEW_VERSION }}.tgz
-
       - name: Upload Cloudzero Agent Chart as Artifact
         uses: actions/upload-artifact@v4
         with:
           name: agent-chart
           path: .deploy/cloudzero-agent-${{ env.NEW_VERSION }}.tgz
-
 
       - name: Checkout GH Pages
         run: |
@@ -133,7 +99,6 @@ jobs:
 
       - name: Move release Tarball
         run: |
-          cp .deploy/cloudzero-insights-controller-${{ env.NEW_VERSION }}.tgz ./
           cp .deploy/cloudzero-agent-${{ env.NEW_VERSION }}.tgz ./
           rm -fr .deploy
 
@@ -143,7 +108,7 @@ jobs:
       - name: Save Index in GH Pages
         run: |
           # copy the new chart and index.yaml
-          git add cloudzero-insights-controller-${{ env.NEW_VERSION }}.tgz cloudzero-agent-${{ env.NEW_VERSION }}.tgz index.yaml 
+          git add cloudzero-agent-${{ env.NEW_VERSION }}.tgz index.yaml 
           git commit -m "Updating ${{ env.NEW_VERSION }} Index"
           git push origin gh-pages
         continue-on-error: true


### PR DESCRIPTION

### Description
 similar to https://github.com/Cloudzero/cloudzero-charts/pull/150, but doing it in the release branch because I forgot that the release needs release docs available, which are not available in `develop`


### Checklist

- [ ] I have added documentation for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`