### PR TITLE
[CP-25165] allow non-main branch to run release workflow

### DIFF
--- a/.github/workflows/build-and-publish-chart.yml
+++ b/.github/workflows/build-and-publish-chart.yml
@@ -8,6 +8,10 @@ on:
         description: 'Version to use for the release'
         required: false
         default: ''
+      branch:
+        description: 'Branch to use for the release'
+        required: true
+        default: 'main'
 
 jobs:
   build-and-publish-chart:
@@ -24,7 +28,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v4
         with:
-          ref: main
+          ref: ${{ github.event.inputs.branch }}
           fetch-depth: 0
 
       - name: Set up Git


### PR DESCRIPTION

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`