### PR TITLE
CP-25165: checkout correct branch before running release

### DIFF
--- a/.github/workflows/build-and-publish-chart.yml
+++ b/.github/workflows/build-and-publish-chart.yml
@@ -24,7 +24,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      # Step 1: Checkout and Setup
+      # Step 1: Prepare Branches
+      - name: Prepare Branches
+        run: |
+          git checkout develop
+          git pull --rebase origin develop
+          git checkout main
+          git pull --rebase origin main
+          git merge develop
+
+      # Step 2: Checkout and Setup
       - name: Checkout Code
         uses: actions/checkout@v4
         with:
@@ -38,15 +47,6 @@ jobs:
       
       - name: Fetch All Branches
         run: git fetch --all
-
-      # Step 2: Prepare Branches
-      - name: Prepare Branches
-        run: |
-          git checkout develop
-          git pull --rebase origin develop
-          git checkout main
-          git pull --rebase origin main
-          git merge develop
 
       # Step 3: Helm Setup
       - name: Install Helm


### PR DESCRIPTION
moving the order of the steps so that we checkout the inputted branch before running

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`