### PR TITLE
CP-25165: checkout the input branch, not main, in release workflow

### DIFF
--- a/.github/workflows/build-and-publish-chart.yml
+++ b/.github/workflows/build-and-publish-chart.yml
@@ -124,7 +124,7 @@ jobs:
           rm -fr .deploy charts/cloudzero-agent/charts
           git reset --hard 
           # now checkout docs from main
-          git checkout main -- charts/cloudzero-agent/docs charts/cloudzero-agent/README.md README.md
+          git checkout ${{ github.event.inputs.branch }} -- charts/cloudzero-agent/docs charts/cloudzero-agent/README.md README.md
           git add README.md charts/cloudzero-agent/docs charts/cloudzero-agent/README.md
           git commit -m "Update docs for ${{ env.NEW_VERSION }}"
           git push origin gh-pages
@@ -140,4 +140,3 @@ jobs:
           make_latest: true
           target_commitish: ${{ env.COMMIT_HASH }}
           body_path: ${{ github.workspace }}/charts/cloudzero-agent/docs/releases/${{ env.NEW_VERSION }}.md
-


### PR DESCRIPTION

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`