### PR TITLE
CP-25698: add ability to configure endpoint and scheme

### DIFF
--- a/charts/cloudzero-agent/templates/cm.yaml
+++ b/charts/cloudzero-agent/templates/cm.yaml
@@ -159,7 +159,7 @@ data:
       {{- end}}
   {{- end}}
     remote_write:
-      - url: 'https://{{ include "cloudzero-agent.cleanString" .Values.host }}/v1/container-metrics?cluster_name={{ include "cloudzero-agent.cleanString" .Values.clusterName | urlquery }}&cloud_account_id={{ include "cloudzero-agent.cleanString" .Values.cloudAccountId | urlquery }}&region={{ include "cloudzero-agent.cleanString" .Values.region | urlquery }}'
+      - url: '{{ .Values.scheme }}://{{ include "cloudzero-agent.cleanString" .Values.host }}{{ .Values.endpoint }}?cluster_name={{ include "cloudzero-agent.cleanString" .Values.clusterName | urlquery }}&cloud_account_id={{ include "cloudzero-agent.cleanString" .Values.cloudAccountId | urlquery }}&region={{ include "cloudzero-agent.cleanString" .Values.region | urlquery }}'
         authorization:
           credentials_file: {{ include "cloudzero-agent.secretFileFullPath" . }}
         write_relabel_configs:

--- a/charts/cloudzero-agent/values.yaml
+++ b/charts/cloudzero-agent/values.yaml
@@ -202,6 +202,9 @@ kubeStateMetrics:
 secretAnnotations: {}
 imagePullSecrets: []
 
+scheme: https
+endpoint: /v1/container-metrics
+
 # environment validator image allows for CI to use a different image in testing
 validator:
   serviceEndpoints:


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [CloudZero Code of Conduct](https://github.com/cloudzero/template-cloudzero-open-source/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/cloudzero/template-cloudzero-open-source/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

These are pretty much the minimal changes to allow us to point the agent at the collector.

### References

> Include any links supporting this change such as a:
>
> - GitHub Issue/PR number addressed or fixed
> - StackOverflow post
> - Support forum thread
> - Related pull requests/issues from other repos
>
> If there are no references, simply delete this section.

### Testing

Bascially, add this to your overrides:

```yaml
host: collector-cloudzero-collector.cz-collector.svc.cluster.local
endpoint: /metrics
scheme: http
```

The hostname obviously depends on where you've installed the collector, mine is a service called `collector-cloudzero-collector` in a `cz-collector` namespace.

Once both are installed, you should start seeing traffic coming into the collector (you may need to bump the debug level in the configuration).

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`