### PR TITLE
CP-25822: use namespace in SAN address during certificate generation

### DIFF
--- a/charts/cloudzero-agent/docs/releases/1.0.1-rc1.md
+++ b/charts/cloudzero-agent/docs/releases/1.0.1-rc1.md
@@ -1,0 +1,12 @@
+## [Release 1.0.1-rc1](https://github.com/Cloudzero/cloudzero-agent/compare/v1.0.0-rc1...v1.0.1-rc1) (2025-02-12)
+
+This release fixes an issue in which the internal TLS certificate could create a SAN field with an incorrect service address.
+
+### Upgrade Steps
+Upgrade using the following command:
+```console
+helm upgrade --install <RELEASE_NAME> cloudzero/cloudzero-agent -n <NAMESPACE> --create-namespace -f configuration.example.yaml --version 1.0.1-rc1
+```
+
+#### Bug Fixes
+* **SAN Field Properly Formatted:** Previously, users installing the agent in a non-`default` namespace who were also using the internal TLS certificate generation may have run into an issue in which the certificate is improperly generated. The template now takes the release namespace into account.

--- a/charts/cloudzero-agent/templates/init-job.yaml
+++ b/charts/cloudzero-agent/templates/init-job.yaml
@@ -134,7 +134,7 @@ spec:
               fi
 
               # Generate self-signed certificate and private key
-              openssl req -x509 -newkey rsa:2048 -keyout tls.key -out tls.crt -days 36500 -nodes -subj "/CN={{ include "cloudzero-agent.serviceName" . }}" -addext "subjectAltName = DNS:{{ include "cloudzero-agent.serviceName" . }}.default.svc"
+              openssl req -x509 -newkey rsa:2048 -keyout tls.key -out tls.crt -days 36500 -nodes -subj "/CN={{ include "cloudzero-agent.serviceName" . }}" -addext "subjectAltName = DNS:{{ include "cloudzero-agent.serviceName" . }}.{{ .Release.Namespace }}.svc"
               
               # Base64 encode the certificate
               export CA_BUNDLE=$(cat tls.crt | base64 | tr -d '\n')


### PR DESCRIPTION
### Description

see release notes for description.

### Testing

deploying 1.0.0-rc1 to a `foobar` namespace, I can reproduce an error we sometimes see in our non-cert-manager installs:
```
cloudzero-agent-with-ui-webhook-server-5d876f4bc-f2l2h webhook-server 2025/02/12 14:47:23 http: TLS handshake error from 192.168.90.247:35388: remote error: tls: bad certificate
``` 
installing with this change, I get the expected log:
```
cloudzero-agent-with-ui-webhook-server-766b4bc494-rfl4d webhook-server I0212 15:13:23.417997       1 handler.go:92] Webhook [/validate/pod - UPDATE] - Allowed: true
```

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`