### PR TITLE
CP-25368, CP-25369, CP-25370, CP-25371: add aggregator to Helm chart

### DIFF
--- a/charts/cloudzero-agent/templates/aggregator-deploy.yaml
+++ b/charts/cloudzero-agent/templates/aggregator-deploy.yaml
@@ -1,0 +1,156 @@
+{{- if .Values.aggregator.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+{{- if .Values.aggregator.deploymentAnnotations }}
+  annotations:
+    {{- toYaml .Values.aggregator.deploymentAnnotations | nindent 4 }}
+{{- end }}
+  name: {{ include "cloudzero-agent.aggregator.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "cloudzero-agent.aggregator.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "cloudzero-agent.aggregator.matchLabels" . | nindent 6 }}
+  replicas: {{ .Values.aggregator.replicas }}
+  template:
+    metadata:
+      {{- with .Values.aggregator.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "cloudzero-agent.aggregator.labels" . | nindent 8 }}
+        {{- with .Values.aggregator.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+{{- if .Values.server.priorityClassName }}
+      priorityClassName: "{{ .Values.server.priorityClassName }}"
+{{- end }}
+      serviceAccountName: {{ template "cloudzero-agent.serviceAccountName" . }}
+      containers:
+        - name: {{ include "cloudzero-agent.aggregator.name" . }}-collector
+          image: "{{ .Values.aggregator.image.repository }}:{{ .Values.aggregator.image.tag }}"
+          imagePullPolicy: {{ .Values.aggregator.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.aggregator.collector.port }}
+          command: ["/app/cloudzero-collector", "-config", "{{ .Values.aggregator.mountRoot }}/config/config.yml"]
+          env:
+            - name: SERVER_PORT
+              value: "{{ .Values.aggregator.collector.port }}"
+          volumeMounts:
+            {{- include "cloudzero-agent.apiKeyVolumeMount" . | nindent 12 }}
+            - name: aggregator-config-volume
+              mountPath: {{ .Values.aggregator.mountRoot }}/config
+              readOnly: true
+            - name: aggregator-persistent-storage
+              mountPath: {{ .Values.aggregator.mountRoot }}/data
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: {{ .Values.aggregator.collector.port }}
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: {{ .Values.aggregator.collector.port }}
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            failureThreshold: 3
+          resources:
+            {{- toYaml .Values.aggregator.collector.resources | nindent 12 }}
+
+        - name: {{ include "cloudzero-agent.aggregator.name" . }}-shipper
+          image: "{{ .Values.aggregator.image.repository }}:{{ .Values.aggregator.image.tag }}"
+          imagePullPolicy: {{ .Values.aggregator.image.pullPolicy }}
+          command: ["/app/cloudzero-shipper", "-config", "{{ .Values.aggregator.mountRoot }}/config/config.yml"]
+          env:
+            - name: SERVER_PORT
+              value: "8081"
+          volumeMounts:
+            {{- include "cloudzero-agent.apiKeyVolumeMount" . | nindent 12 }}
+            - name: aggregator-config-volume
+              mountPath: {{ .Values.aggregator.mountRoot }}/config
+              readOnly: true
+            - name: aggregator-persistent-storage
+              mountPath: {{ .Values.aggregator.mountRoot }}/data
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: {{ .Values.aggregator.collector.port }}
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: {{ .Values.aggregator.collector.port }}
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            failureThreshold: 3
+          resources:
+            {{- toYaml .Values.aggregator.shipper.resources | nindent 12 }}
+
+      securityContext:
+        runAsUser: 65534
+        runAsNonRoot: true
+        runAsGroup: 65534
+        fsGroup: 65534
+      dnsPolicy: ClusterFirst
+      {{- include "cloudzero-agent.server.imagePullSecrets" . | nindent 6 -}}
+
+      {{- with .Values.aggregator.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.aggregator.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.aggregator.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  
+    {{- with .Values.server.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      terminationGracePeriodSeconds: {{ default 300 .Values.server.terminationGracePeriodSeconds }}
+      volumes:
+        - name: config-volume
+          configMap:
+            name: {{ template "cloudzero-agent.configMapName" . }}
+        - name: validator-config-volume
+          configMap:
+            name: {{ template "cloudzero-agent.validatorConfigMapName" . }}
+        - name: lifecycle-volume
+          emptyDir: {}
+        {{- if or .Values.existingSecretName .Values.apiKey }}
+        - name: cloudzero-api-key
+          secret:
+            secretName: {{ include "cloudzero-agent.secretName" . }}
+        {{- end }}
+        - name: cloudzero-agent-storage-volume
+        {{- if .Values.server.persistentVolume.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ if .Values.server.persistentVolume.existingClaim }}{{ .Values.server.persistentVolume.existingClaim }}{{- else }}{{ template "cloudzero-agent.server.fullname" . }}{{- end }}
+        {{- else }}
+          emptyDir:
+          {{- if .Values.server.emptyDir.sizeLimit }}
+            sizeLimit: {{ .Values.server.emptyDir.sizeLimit }}
+          {{- else }}
+            {}
+          {{- end }}
+        {{- end }}
+        - name: aggregator-config-volume
+          configMap:
+            name: {{ include "cloudzero-agent.aggregator.name" . }}
+        - name: aggregator-persistent-storage
+          emptyDir: {}
+{{- end }}

--- a/charts/cloudzero-agent/templates/cm.yaml
+++ b/charts/cloudzero-agent/templates/cm.yaml
@@ -159,7 +159,11 @@ data:
       {{- end}}
   {{- end}}
     remote_write:
+      {{ if .Values.aggregator.enabled }}
+      - url: 'http://{{ include "cloudzero-agent.aggregator.name" . }}.{{ .Release.Namespace }}.svc.cluster.local/metrics'
+      {{ else }}
       - url: '{{ .Values.scheme }}://{{ include "cloudzero-agent.cleanString" .Values.host }}{{ .Values.endpoint }}?cluster_name={{ include "cloudzero-agent.cleanString" .Values.clusterName | urlquery }}&cloud_account_id={{ include "cloudzero-agent.cleanString" .Values.cloudAccountId | urlquery }}&region={{ include "cloudzero-agent.cleanString" .Values.region | urlquery }}'
+      {{ end }}
         authorization:
           credentials_file: {{ include "cloudzero-agent.secretFileFullPath" . }}
         write_relabel_configs:
@@ -232,3 +236,33 @@ data:
       annotations:
         {{- .Values.insightsController.annotations | toYaml | nindent 8 }}
 {{- end }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "cloudzero-agent.aggregator.name" . }}
+  namespace: {{ .Release.Namespace }}
+data:
+  config.yml: |-
+    cloud_account_id: "{{ .Values.cloudAccountId }}"
+    region: "{{ .Values.region }}"
+    cluster_name: "{{ .Values.clusterName }}"
+
+    server:
+      mode: http
+      port: {{ .Values.aggregator.collector.port }}
+
+    logging:
+      level: "{{ .Values.aggregator.logging.level }}"
+
+    database:
+      storage_path: {{ .Values.aggregator.mountRoot }}/data
+      max_records: 1000000
+      compression_level: 8
+
+    cloudzero:
+      api_key_path: {{ include "cloudzero-agent.secretFileFullPath" . }}
+      send_interval: 1m
+      send_timeout: 10s
+      rotate_interval: 30m
+      host: {{ .Values.host }}

--- a/charts/cloudzero-agent/templates/deploy.yaml
+++ b/charts/cloudzero-agent/templates/deploy.yaml
@@ -39,12 +39,7 @@ spec:
             - -c
             - cp -r /app /checks/bin/ && cloudzero-agent-validator d pre-start -f /checks/config/validator.yml
           volumeMounts:
-          {{- if or .Values.existingSecretName .Values.apiKey }}
-            - name: cloudzero-api-key
-              mountPath: {{ .Values.serverConfig.containerSecretFilePath }}
-              subPath: ""
-              readOnly: true
-          {{- end }}
+          {{- include "cloudzero-agent.apiKeyVolumeMount" . | nindent 12 }}
             - name: lifecycle-volume
               mountPath: /checks/bin/
             - name: validator-config-volume
@@ -135,12 +130,8 @@ spec:
               mountPath: /check/
             - name: validator-config-volume
               mountPath: /check/app/config/
-          {{- if or .Values.existingSecretName .Values.apiKey }}
-            - name: cloudzero-api-key
-              mountPath: {{ .Values.serverConfig.containerSecretFilePath }}
-              subPath: ""
-              readOnly: true
-          {{- end }}
+            {{- include "cloudzero-agent.apiKeyVolumeMount" . | nindent 12 }}
+
       securityContext:
         runAsUser: 65534
         runAsNonRoot: true
@@ -189,5 +180,5 @@ spec:
             sizeLimit: {{ .Values.server.emptyDir.sizeLimit }}
           {{- else }}
             {}
-          {{- end -}}
-        {{- end -}}
+          {{- end }}
+        {{- end }}

--- a/charts/cloudzero-agent/templates/service.yaml
+++ b/charts/cloudzero-agent/templates/service.yaml
@@ -13,3 +13,19 @@ spec:
       name: http
   selector:
     {{- include "cloudzero-agent.insightsController.server.matchLabels" . | nindent 4 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: {{ include "cloudzero-agent.aggregator.name" . }}
+  labels:
+    {{- include "cloudzero-agent.aggregator.labels" . | nindent 4 }}
+spec:
+  selector:
+    {{- include "cloudzero-agent.aggregator.matchLabels" . | nindent 4 }}
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: {{ .Values.aggregator.collector.port }}
+  type: ClusterIP

--- a/charts/cloudzero-agent/values.yaml
+++ b/charts/cloudzero-agent/values.yaml
@@ -392,3 +392,16 @@ configmapReload:
 
     containerSecurityContext: {}
     resources: {}
+
+aggregator:
+  enabled: false
+  replicas: 1
+  logging:
+    level: info
+  collector:
+    port: 8080
+  mountRoot: /cloudzero
+  image:
+    repository: ghcr.io/cloudzero/cloudzero-insights-controller/cloudzero-insights-controller
+    tag: latest
+    pullPolicy: IfNotPresent


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [CloudZero Code of Conduct](https://github.com/cloudzero/template-cloudzero-open-source/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/cloudzero/template-cloudzero-open-source/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

This adds the the aggregator to the helm chart.

### References

> Include any links supporting this change such as a:
>
> - GitHub Issue/PR number addressed or fixed
> - StackOverflow post
> - Support forum thread
> - Related pull requests/issues from other repos
>
> If there are no references, simply delete this section.

### Testing

To test, you'll need to specify a few values in an overrides file:

```yaml
aggregator:
  enabled: true
  logging:
    level: trace
  image:
    tag: dev-214f55f01b92680014afc3b1957ba8a9e96cd56c
    pullPolicy: Always
```

The image tag will change from time to time, obviously, as we continue working on the code, but that one currently works well and has a few extra trace-level logs so it should be a bit easier to see activity. You also don't technically need to set the log level to trace, but it's nice to see the activity to verify that everything is communicating.

Once that's all up and running, I usually just do a `kubectl -n my-namespace get pods`, then look for the `cz-agent-aggregator-...` one (it's probably the first in the list. Once you have it, you can do something like `kubectl -n my-namespace logs -f pods/cz-agent-aggregator-669789c7f8-5tdxg -c cz-agent-aggregator-collector` to see the logs. You should be able to see metrics coming in from the agent.

After a while, you should also be able to do something like `kubectl -n my-namespace exec cz-agent-aggregator-669789c7f8-5tdxg -- ls /cloudzero/data` to see the metrics data, and of course you can copy that data out with something like `kubectl -n my-namespace cp pods/cz-agent-aggregator-669789c7f8-5tdxg:/cloudzero/data/metric_....json.br data.json.br`

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`