### PR TITLE
[CP-26202][CP-26358]: add istio doc, minor fixes/improvements

### DIFF
--- a/charts/cloudzero-agent/README.md
+++ b/charts/cloudzero-agent/README.md
@@ -214,10 +214,6 @@ kubectl create secret -n example-namespace generic example-secret-name --from-li
 
 The secret can then be used with `existingSecretName`.
 
-### Memory Sizing
-
-Please see the [sizing guide](./docs/sizing-guide.md) in the docs directory.
-
 ### Update Helm Chart
 If you are updating an existing installation, pull the latest chart information:
 
@@ -279,5 +275,7 @@ To receive a notification when a new version of the chart is [released](https://
 
 - [Memory Sizing Guide](./docs/sizing-guide.md)
 - [Deployment Validation Guide](./docs/deploy-validation.md)
+- Using istio? [Read on here](./docs/istio.md)
+- [Chart release notes](./docs/releases/)
 
 ---

--- a/charts/cloudzero-agent/docs/istio.md
+++ b/charts/cloudzero-agent/docs/istio.md
@@ -29,7 +29,7 @@ insightsController:
 ---
 
 ## **Option 2: Disable Envoy for Webhook Ports Only**
-To prevent only requests to a single port on the webhook-server pods from being routed through envoy:
+To prevent only requests to a single port on the webhook-server pods from being routed through envoy, apply the following annotation:
 
 ```yaml
 insightsController:

--- a/charts/cloudzero-agent/docs/istio.md
+++ b/charts/cloudzero-agent/docs/istio.md
@@ -26,6 +26,8 @@ insightsController:
       sidecar.istio.io/inject: "false"
 ```
 
+This annotation prevents the Istio sidecar from being injected into the `webhook-server` pods, while the rest of the cluster retains normal Istio functionality.
+
 ---
 
 ## **Option 2: Disable Envoy for Webhook Ports Only**

--- a/charts/cloudzero-agent/docs/istio.md
+++ b/charts/cloudzero-agent/docs/istio.md
@@ -27,7 +27,9 @@ insightsController:
     podAnnotations:
       traffic.sidecar.istio.io/excludeInboundPorts: "8443"
 ```
-In this case, the pods will still have an istio sidecar injected. For more details, see [here](https://istio.io/latest/docs/reference/config/annotations/#SidecarTrafficExcludeInboundPorts).
+In this case, the pods will still have an Istio sidecar injected, but traffic to port 8443 (the webhook port) will bypass envoy.
+
+For more details, see [Istio Documentation](https://istio.io/latest/docs/reference/config/annotations/#SidecarTrafficExcludeInboundPorts).
 
 ---
 ## **Option 3: Disable mTLS for `cloudzero-agent`**

--- a/charts/cloudzero-agent/docs/istio.md
+++ b/charts/cloudzero-agent/docs/istio.md
@@ -1,0 +1,60 @@
+# Installing `cloudzero-agent` in Istio Enabled Clusters
+
+When installing the `cloudzero-agent` Helm chart in a Kubernetes cluster that uses Istio, additional steps may be required to ensure proper functioning. This is because Istio automatically configures sidecars to use **mutual TLS (mTLS)**, which can interfere with the agent’s existing TLS communication.
+
+To successfully deploy `cloudzero-agent`, either **exclude some communication from redirecting through envoy**, **disable Istio sidecar injection for a subset of the agent workloads**, or **disable mTLS for a subset of the agent workloads**.
+
+---
+
+## **Option 1: Disable Sidecar Injection for `cloudzero-agent` webhook-server Pods Only**
+To disable the sidecar injection **only for a subset of the pods deployed by the cluster**, update the chart input values with the following annotation:
+
+```yaml
+insightsController:
+  server:
+    podAnnotations:
+      sidecar.istio.io/inject: "false"
+```
+
+---
+
+## **Option 2: Disable Envoy for Webhook Ports Only**
+To prevent only requests to a single port on the webhook-server pods from being routed through envoy:
+
+```yaml
+insightsController:
+  server:
+    podAnnotations:
+      traffic.sidecar.istio.io/excludeInboundPorts: "8443"
+```
+In this case, the pods will still have an istio sidecar injected. For more details, see [here](https://istio.io/latest/docs/reference/config/annotations/#SidecarTrafficExcludeInboundPorts).
+
+---
+## **Option 3: Disable mTLS for `cloudzero-agent`**
+To disable mTLS for the `cloudzero-agent` service, apply the following `PeerAuthentication` resource:
+
+```yaml
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
+metadata:
+  name: cloudzero-agent-mtls
+  namespace: <cloudzero-namespace>
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: webhook-server
+  mtls:
+    mode: DISABLE
+```
+
+### **Steps to Apply:**
+1. Replace `<your-namespace>` with the namespace where `cloudzero-agent` is deployed.
+2. Apply the resource:
+   ```sh
+   kubectl apply -f cloudzero-agent-mtls.yaml
+   ```
+3. Deploy the `cloudzero-agent` chart as instructed in the chart README.md
+
+This configuration **disables mTLS for `cloudzero-agent` webhook-server pods only**, while keeping it enabled for the rest of the cluster.
+
+---

--- a/charts/cloudzero-agent/templates/_helpers.tpl
+++ b/charts/cloudzero-agent/templates/_helpers.tpl
@@ -340,7 +340,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 */}}
 {{- define "cloudzero-agent.insightsController.server.webhookFullname" -}}
 {{- if .Values.server.fullnameOverride -}}
-{{- printf "%s-%s" .Values.server.fullnameOverride webhook | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s-webhook" .Values.server.fullnameOverride | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- if contains $name .Release.Name -}}

--- a/charts/cloudzero-agent/templates/_helpers.tpl
+++ b/charts/cloudzero-agent/templates/_helpers.tpl
@@ -340,7 +340,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 */}}
 {{- define "cloudzero-agent.insightsController.server.webhookFullname" -}}
 {{- if .Values.server.fullnameOverride -}}
-{{- .Values.server.fullnameOverride | trunc 63 | trimSuffix "-" -}}-webhook
+{{- .Values.server.fullnameOverride | trunc 56 | trimSuffix "-" -}}-webhook
 {{- else -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- if contains $name .Release.Name -}}
@@ -404,7 +404,7 @@ Name for the backfill job resource
 {{- define "cloudzero-agent.initBackfillJobName" -}}
 {{- $name := printf "%s-backfill-%s" .Release.Name .Chart.Version }}
 {{- $imageRef := splitList ":" (include  "cloudzero-agent.initBackfillJob.imageReference" .) | last }}
-{{- printf "%s-%s" $name ($imageRef | trunc 6) | trunc 61 | replace "." "-" -}}
+{{- printf "%s-%s" $name ($imageRef | trunc 6) | trunc 61 | replace "." "-" | trimSuffix "-" -}}
 {{- end }}
 
 {{/*

--- a/charts/cloudzero-agent/templates/_helpers.tpl
+++ b/charts/cloudzero-agent/templates/_helpers.tpl
@@ -340,7 +340,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 */}}
 {{- define "cloudzero-agent.insightsController.server.webhookFullname" -}}
 {{- if .Values.server.fullnameOverride -}}
-{{- .Values.server.fullnameOverride | trunc 56 | trimSuffix "-" -}}-webhook
+{{- printf "%s-%s" .Values.server.fullnameOverride webhook | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- if contains $name .Release.Name -}}

--- a/charts/cloudzero-agent/templates/init-job.yaml
+++ b/charts/cloudzero-agent/templates/init-job.yaml
@@ -125,7 +125,7 @@ spec:
 
               CA_BUNDLE=${caBundles[0]}
               for caBundle in "${caBundles[@]}"; do
-                  if [[ "$caBundle" != "missing" ]]; then
+                  if [[ "$caBundle" = "missing" ]]; then
                       echo "Empty caBundle found in ValidatingWebhookConfiguration."
                       GENERATE_CERTIFICATE=true
                   fi

--- a/charts/cloudzero-agent/templates/init-job.yaml
+++ b/charts/cloudzero-agent/templates/init-job.yaml
@@ -118,12 +118,17 @@ spec:
               {{- range $configType, $configs := .Values.insightsController.webhooks.configurations }}
               {{- $webhookName := printf "%s-%s" (include "cloudzero-agent.validatingWebhookConfigName" $) $configType }}
               {{- if or (index $.Values.insightsController.labels.resources $configType) (index $.Values.insightsController.annotations.resources $configType) }}
-              caBundles+=($(kubectl get validatingwebhookconfiguration {{ $webhookName }} -o jsonpath='{.webhooks[0].clientConfig.caBundle}'))
+              wh_{{ $configType }}_caBundle=($(kubectl get validatingwebhookconfiguration {{ $webhookName }} -o jsonpath='{.webhooks[0].clientConfig.caBundle}'))
+              caBundles+=("${wh_{{ $configType }}_caBundle:-missing }")
               {{- end }}
               {{- end }}
 
               CA_BUNDLE=${caBundles[0]}
               for caBundle in "${caBundles[@]}"; do
+                  if [[ "$caBundle" != "missing" ]]; then
+                      echo "Empty caBundle found in ValidatingWebhookConfiguration."
+                      GENERATE_CERTIFICATE=true
+                  fi
                   if [[ "$caBundle" != "$CA_BUNDLE" ]]; then
                       echo "Mismatch found between ValidatingWebhookConfiguration caBundle values."
                         GENERATE_CERTIFICATE=true

--- a/charts/cloudzero-agent/templates/init-job.yaml
+++ b/charts/cloudzero-agent/templates/init-job.yaml
@@ -125,7 +125,7 @@ spec:
 
               CA_BUNDLE=${caBundles[0]}
               for caBundle in "${caBundles[@]}"; do
-                  if [[ "$caBundle" = "missing" ]]; then
+                  if [[ "$caBundle" == "missing" ]]; then
                       echo "Empty caBundle found in ValidatingWebhookConfiguration."
                       GENERATE_CERTIFICATE=true
                   fi

--- a/charts/cloudzero-agent/templates/webhooks.yaml
+++ b/charts/cloudzero-agent/templates/webhooks.yaml
@@ -12,7 +12,7 @@ metadata:
   {{- include "cloudzero-agent.webhooks.annotations" $ | nindent 2 }}
 webhooks:
   - name: {{ include "cloudzero-agent.validatingWebhookName" $ }}
-    namespaceSelector: {{ toYaml $.Values.insightsController.webhooks.namespaceSelector }}
+    namespaceSelector: {{ toYaml $.Values.insightsController.webhooks.namespaceSelector | nindent 6 }}
     failurePolicy: Ignore
     rules:
       - operations: [ "CREATE", "UPDATE" ]

--- a/charts/cloudzero-agent/values.yaml
+++ b/charts/cloudzero-agent/values.yaml
@@ -182,7 +182,7 @@ initCertJob:
     serviceAccountName: ""
     clusterRoleName: ""
     clusterRoleBindingName: ""
-  ttlSecondsAfterFinished: 180
+  ttlSecondsAfterFinished: 5
 
 kubeStateMetrics:
   enabled: true


### PR DESCRIPTION
### Description

- fixing namespaceSelector indentation
- fix certificate update in particular upgrade path
- add istio documentation

### Testing

1. namespaceSelector should be settable:
given:
```yaml
insightsController:
  webhooks:
    namespaceSelector:
      matchExpressions:
        - key: foo
          operator: In
          values:
            - bar
```
and namespaces labeled accordingly:
```
kg ns -l foo=bar
NAME      STATUS   AGE
default   Active   253d
foobar    Active   13d
```
- pod creation in foobar/default namespaces shows activity ✅ 
- pod creation in non-foobar/default namespaces does not show activity ✅ 

2. fullnameOverride should working as expected
given:
```yaml
server:
  fullnameOverride: "special-name"
```
resources are deployed accordingly and correctly:
```
special-name-698c667457-sx6zz                              2/2     Running     0          3m6s
special-name-webhook-5b6cc49fc-8nbg6                       1/1     Running     0          3m6s
special-name-webhook-5b6cc49fc-bnxct                       1/1     Running     0          3m6s
special-name-webhook-5b6cc49fc-llwkl                       1/1     Running     0          3m6s
```

3. cert should be successfully generated after webhook config is added post initial installation
given a normal installation, and then updating with 
```yaml
insightsController:
    resources:
      deployments: true # this is the only change - adds a webhook config after the fact
```
the init-cert job runs again and forces all certs to match. pods and deployments register in the webhook logs ✅ 

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`