### PR TITLE
CP-26389: More release notes for 1.0.1

### DIFF
--- a/charts/cloudzero-agent/docs/releases/1.0.1.md
+++ b/charts/cloudzero-agent/docs/releases/1.0.1.md
@@ -1,6 +1,6 @@
 ## [Release 1.0.1](https://github.com/Cloudzero/cloudzero-charts/compare/1.0.0...1.0.1) (2025-03-02)
 
-This release fixes two issues relating to template rendering and TLS certificate generation, as well as adding documentation for Istio enabled clusters.
+This release fixes two issues relating to template rendering and TLS certificate generation, as well as adding documentation for Istio enabled clusters. In addition, some other bug fixes around prometheus metrics, logging, and sqlite were added.
 
 ### Upgrade Steps
 Upgrade using the following command:
@@ -11,6 +11,10 @@ helm upgrade --install <RELEASE_NAME> cloudzero/cloudzero-agent -n <NAMESPACE> -
 ### Bug Fixes
 * **Webhook Resource Names Trimmed Appropriately:** Fixes an issue in which the name used by webhook resources adds a suffix after trimming, which can potentially allow resource names that violate Kubernetes naming rules.
 * **Certificate Generation Runs For All Webhook Configuration Changes:** Fixes an issue in which the TLS certificate generation initialization Job does not run if a `ValidatingWebhookConfiguration` is created after initial installation.
+* **Invalid Prometheus Metric Label Name:** Fixes an issue where supplying an invalid label name to a Prometheus metric causes a panic.
+* **Utilization of Default Kubernetes Logger:** Removes the last utilization of the default Kubernetes logger, which causes logging levels defined in the configuration to not be respected.
 
 ### Improvements
 * **Shorter TTL for `init-cert` Job:** The `init-cert` Job is now cleaned up after 5 seconds, so that repeated installations regenerate certificates as needed.
+* **Improvements to SQLite Testing:** The SQLite connection string was edited for improved clarity, and a concurrency test was added.
+* **Various Logging Changes:** Some logging messages were downgraded from `info` to `debug`.

--- a/charts/cloudzero-agent/values.yaml
+++ b/charts/cloudzero-agent/values.yaml
@@ -315,7 +315,7 @@ insightsController:
     # imagePullSecrets: []
     image:
       repository: ghcr.io/cloudzero/cloudzero-insights-controller/cloudzero-insights-controller
-      tag: 0.1.1
+      tag: 0.1.2
       pullPolicy: Always
     port: 8443
     read_timeout: 10s


### PR DESCRIPTION
### Description

Added some more release notes for version 1.0.1 of the insights controller, that reference the changes made in [this release](https://github.com/Cloudzero/cloudzero-insights-controller/releases/tag/0.1.2).


### References

- [Release 0.1.2 of the insights controller](https://github.com/Cloudzero/cloudzero-insights-controller/releases/tag/0.1.2)
