### PR TITLE
CP-26856: update default scrape intervals to 60s

### DIFF
--- a/charts/cloudzero-agent/values.yaml
+++ b/charts/cloudzero-agent/values.yaml
@@ -124,16 +124,16 @@ prometheusConfig:
   configMapNameOverride: ''
   configMapAnnotations: {}
   configOverride: ''
-  globalScrapeInterval: 120s
+  globalScrapeInterval: 60s
   scrapeJobs:
     # -- Enables the kube-state-metrics scrape job.
     kubeStateMetrics:
       enabled: true
-      scrapeInterval: 120s  # Scrape interval for kubeStateMetrics job
+      scrapeInterval: 60s  # Scrape interval for kubeStateMetrics job
     # -- Enables the cadvisor scrape job.
     cadvisor:
       enabled: true
-      scrapeInterval: 120s  # Scrape interval for nodesCadvisor job
+      scrapeInterval: 60s  # Scrape interval for nodesCadvisor job
     # -- Enables the prometheus scrape job.
     prometheus:
       enabled: true


### PR DESCRIPTION
### Description
the scrape interval is a balance between resource usage and more data points. this change leans us more towards more data points at the risk of resource issues

### Testing

in progress ...

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated scraping intervals for metrics collection, ensuring metrics are gathered more frequently for improved monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->