### PR TITLE
CP-25384, CP-25375: cost/observability metrics split in Gator, scraping Gator metrics in Prometheus

### DIFF
--- a/charts/cloudzero-agent/templates/_helpers.tpl
+++ b/charts/cloudzero-agent/templates/_helpers.tpl
@@ -156,6 +156,35 @@ Combine metric lists
 {{- end -}}
 
 {{/*
+Generate metric filters
+*/}}
+{{- define "cloudzero-agent.generateMetricFilters" -}}
+{{- if ne 0 (add (len .filters.exact) (len .filters.additionalExact) (len .filters.prefix) (len .filters.additionalPrefix) (len .filters.suffix) (len .filters.additionalSuffix) (len .filters.contains) (len .filters.additionalContains) (len .filters.regex) (len .filters.additionalRegex)) }}
+{{ .name }}:
+{{- range $pattern := uniq (concat .filters.exact .filters.additionalExact) }}
+  - pattern: "{{ $pattern }}"
+    match: exact
+{{- end }}
+{{- range $pattern := uniq (concat .filters.prefix .filters.additionalPrefix) }}
+  - pattern: "{{ $pattern }}"
+    match: prefix
+{{- end }}
+{{- range $pattern := uniq (concat .filters.suffix .filters.additionalSuffix) }}
+  - pattern: "{{ $pattern }}"
+    match: suffix
+{{- end }}
+{{- range $pattern := uniq (concat .filters.contains .filters.additionalContains) }}
+  - pattern: "{{ $pattern }}"
+    match: contains
+{{- end }}
+{{- range $pattern := uniq (concat .filters.regex .filters.additionalRegex) }}
+  - pattern: "{{ $pattern }}"
+    match: regex
+{{- end }}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Required metric labels
 */}}
 {{- define "cloudzero-agent.requiredMetricLabels" -}}

--- a/charts/cloudzero-agent/templates/cm.yaml
+++ b/charts/cloudzero-agent/templates/cm.yaml
@@ -276,6 +276,7 @@ data:
     database:
       storage_path: {{ .Values.aggregator.mountRoot }}/data
       max_records: {{ .Values.aggregator.database.maxRecords }}
+      max_interval: {{ .Values.aggregator.database.maxInterval }}
       compression_level: {{ .Values.aggregator.database.compressionLevel }}
       purge_rules:
         metrics_older_than: {{ .Values.aggregator.database.purgeRules.metricsOlderThan }}

--- a/charts/cloudzero-agent/templates/cm.yaml
+++ b/charts/cloudzero-agent/templates/cm.yaml
@@ -257,12 +257,12 @@ data:
 
     database:
       storage_path: {{ .Values.aggregator.mountRoot }}/data
-      max_records: 1000000
-      compression_level: 8
+      max_records: {{ .Values.aggregator.database.maxRecords }}
+      compression_level: {{ .Values.aggregator.database.compressionLevel }}
 
     cloudzero:
       api_key_path: {{ include "cloudzero-agent.secretFileFullPath" . }}
-      send_interval: 1m
-      send_timeout: 10s
-      rotate_interval: 30m
+      send_interval: {{ .Values.aggregator.cloudzero.sendInterval }}
+      send_timeout: {{ .Values.aggregator.cloudzero.sendTimeout }}
+      rotate_interval: {{ .Values.aggregator.cloudzero.rotateInterval }}
       host: {{ .Values.host }}

--- a/charts/cloudzero-agent/templates/cm.yaml
+++ b/charts/cloudzero-agent/templates/cm.yaml
@@ -260,6 +260,12 @@ data:
     region: "{{ .Values.region }}"
     cluster_name: "{{ .Values.clusterName }}"
 
+    metrics:
+      {{- include "cloudzero-agent.generateMetricFilters" (dict "name" "cost" "filters" .Values.metricFilters.cost.name) | nindent 6 }}
+      {{- include "cloudzero-agent.generateMetricFilters" (dict "name" "cost_labels" "filters" .Values.metricFilters.cost.labels) | nindent 6 }}
+      {{- include "cloudzero-agent.generateMetricFilters" (dict "name" "observability" "filters" .Values.metricFilters.observability.name) | nindent 6 }}
+      {{- include "cloudzero-agent.generateMetricFilters" (dict "name" "observability_labels" "filters" .Values.metricFilters.observability.labels) | nindent 6 }}
+
     server:
       mode: http
       port: {{ .Values.aggregator.collector.port }}

--- a/charts/cloudzero-agent/templates/cm.yaml
+++ b/charts/cloudzero-agent/templates/cm.yaml
@@ -277,6 +277,10 @@ data:
       storage_path: {{ .Values.aggregator.mountRoot }}/data
       max_records: {{ .Values.aggregator.database.maxRecords }}
       compression_level: {{ .Values.aggregator.database.compressionLevel }}
+      purge_rules:
+        metrics_older_than: {{ .Values.aggregator.database.purgeRules.metricsOlderThan }}
+        lazy: {{ .Values.aggregator.database.purgeRules.lazy }}
+        percent: {{ .Values.aggregator.database.purgeRules.percent }}
 
     cloudzero:
       api_key_path: {{ include "cloudzero-agent.secretFileFullPath" . }}

--- a/charts/cloudzero-agent/templates/cm.yaml
+++ b/charts/cloudzero-agent/templates/cm.yaml
@@ -142,6 +142,18 @@ data:
             regex: "^({{ join "|" .Values.insightsMetrics }})$"
             action: keep
       {{- end }}
+      {{- if and .Values.aggregator.enabled  .Values.prometheusConfig.scrapeJobs.aggregator.enabled }}
+      - job_name: cloudzero-aggregator-job
+        scrape_interval: {{ .Values.prometheusConfig.scrapeJobs.prometheus.scrapeInterval }}
+        static_configs:
+          - targets:
+            - {{ include "cloudzero-agent.aggregator.name" . }}.{{ .Release.Namespace }}.svc.cluster.local
+        metrics_path: /metrics
+        metric_relabel_configs:
+          - source_labels: [__name__]
+            regex: "^({{ join "|" .Values.aggregatorMetrics }})$"
+            action: keep
+      {{- end }}
       {{- if .Values.prometheusConfig.scrapeJobs.prometheus.enabled }}
       - job_name: static-prometheus
         scrape_interval: {{ .Values.prometheusConfig.scrapeJobs.prometheus.scrapeInterval }}

--- a/charts/cloudzero-agent/values.yaml
+++ b/charts/cloudzero-agent/values.yaml
@@ -616,6 +616,7 @@ aggregator:
     rotateInterval: 30m
   database:
     maxRecords: 1500000
+    maxInterval: 10m
     compressionLevel: 8
     purgeRules:
       metricsOlderThan: 2160h

--- a/charts/cloudzero-agent/values.yaml
+++ b/charts/cloudzero-agent/values.yaml
@@ -117,6 +117,32 @@ prometheusMetrics:
   - prometheus_target_scrape_pools_total
   - prometheus_target_sync_failed_total
   - prometheus_target_sync_length_seconds
+aggregatorMetrics:
+  - go_gc_duration_seconds
+  - go_gc_duration_seconds_count
+  - go_gc_duration_seconds_sum
+  - go_gc_gogc_percent
+  - go_gc_gomemlimit_bytes
+  - go_goroutines
+  - go_memstats_alloc_bytes
+  - go_memstats_heap_alloc_bytes
+  - go_memstats_heap_idle_bytes
+  - go_memstats_heap_inuse_bytes
+  - go_memstats_heap_objects
+  - go_memstats_last_gc_time_seconds
+  - go_memstats_alloc_bytes
+  - go_memstats_stack_inuse_bytes
+  - go_threads
+  - http_request_duration_seconds_bucket
+  - http_request_duration_seconds_count
+  - http_request_duration_seconds_sum
+  - http_requests_total
+  - prometheus_remote_storage_exemplars_in_total
+  - prometheus_remote_storage_histograms_in_total
+  - prometheus_remote_storage_samples_in_total
+  - prometheus_remote_storage_string_interner_zero_reference_releases_total
+  - promhttp_metric_handler_requests_in_flight
+  - promhttp_metric_handler_requests_total
 # -- Any items added to this array will be added to the metrics that are sent to CloudZero, in addition to the minimal labels that CloudZero requires.
 additionalMetricLabels: []
 
@@ -138,6 +164,9 @@ prometheusConfig:
     prometheus:
       enabled: true
       scrapeInterval: 120s  # Scrape interval for prometheus job
+    aggregator:
+      enabled: true
+      scrapeInterval: 120s  # Scrape interval for aggregator job
     # -- Any items added to this list will be added to the Prometheus scrape configuration.
     additionalScrapeJobs: []
 

--- a/charts/cloudzero-agent/values.yaml
+++ b/charts/cloudzero-agent/values.yaml
@@ -617,6 +617,10 @@ aggregator:
   database:
     maxRecords: 1500000
     compressionLevel: 8
+    purgeRules:
+      metricsOlderThan: 2160h
+      lazy: true
+      percent: 20
   collector:
     port: 8080
     resources:

--- a/charts/cloudzero-agent/values.yaml
+++ b/charts/cloudzero-agent/values.yaml
@@ -146,6 +146,184 @@ aggregatorMetrics:
 # -- Any items added to this array will be added to the metrics that are sent to CloudZero, in addition to the minimal labels that CloudZero requires.
 additionalMetricLabels: []
 
+# metricFilters is used to determine which metrics are sent to CloudZero, as
+# well as whether they are considered to be cost metrics or observability
+# metrics.
+#
+# There are two sets of filters for each type (cost/observability): name and
+# labels. The name filters are applied to the name to determine whether the
+# metric should be included in the relevant output. If it is to be included, the
+# relevant labels filters are applied to each label to determine whether the
+# label should be included.
+#
+# In the event that there are no filters, the subject is always assumed to
+# match.
+#
+# Note that for each match type (exact, prefix, suffix, contains, regex) there
+# is an "additional..." property. This is to allow you to supply supplemental
+# filters without clobbering the defaults. In general, the "additional..."
+# properties should be used in your overrides file, and the unprefixed versions
+# should be left alone.
+metricFilters:
+  cost:
+    name:
+      exact:
+        - container_cpu_usage_seconds_total
+        - container_memory_working_set_bytes
+        - container_network_receive_bytes_total
+        - container_network_transmit_bytes_total
+        - kube_node_info
+        - kube_node_status_capacity
+        - kube_pod_container_resource_limits
+        - kube_pod_container_resource_requests
+        - kube_pod_labels
+        - kube_pod_info
+      prefix:
+        - "cloudzero_"
+      suffix: []
+      contains: []
+      regex: []
+
+      additionalExact: []
+      additionalPrefix: []
+      additionalSuffix: []
+      additionalContains: []
+      additionalRegex: []
+    labels:
+      exact:
+        - board_asset_tag
+        - container
+        - created_by_kind
+        - created_by_name
+        - image
+        - instance
+        - name
+        - namespace
+        - node
+      prefix:
+        - "_"
+        - "label_"
+        - "app.kubernetes.io/"
+        - "k8s."
+      suffix: []
+      contains: []
+      regex: []
+      additionalExact: []
+      additionalPrefix: []
+      additionalSuffix: []
+      additionalContains: []
+      additionalRegex: []
+
+  observability:
+    name:
+      exact:
+        - go_gc_duration_seconds
+        - go_gc_duration_seconds_count
+        - go_gc_duration_seconds_sum
+        - go_gc_gogc_percent
+        - go_gc_gomemlimit_bytes
+        - go_goroutines
+        - go_memstats_alloc_bytes
+        - go_memstats_heap_alloc_bytes
+        - go_memstats_heap_idle_bytes
+        - go_memstats_heap_inuse_bytes
+        - go_memstats_heap_objects
+        - go_memstats_last_gc_time_seconds
+        - go_memstats_stack_inuse_bytes
+        - go_threads
+        - http_request_duration_seconds_bucket
+        - http_request_duration_seconds_count
+        - http_request_duration_seconds_sum
+        - http_requests_total
+        - process_cpu_seconds_total
+        - process_max_fds
+        - process_open_fds
+        - process_resident_memory_bytes
+        - process_start_time_seconds
+        - process_virtual_memory_bytes
+        - process_virtual_memory_max_bytes
+        - prometheus_agent_corruptions_total
+        - prometheus_api_remote_read_queries
+        - prometheus_http_requests_total
+        - prometheus_notifications_alertmanagers_discovered
+        - prometheus_notifications_dropped_total
+        - prometheus_remote_storage_bytes_total
+        - prometheus_remote_storage_exemplars_in_total
+        - prometheus_remote_storage_histograms_failed_total
+        - prometheus_remote_storage_histograms_in_total
+        - prometheus_remote_storage_histograms_total
+        - prometheus_remote_storage_metadata_bytes_total
+        - prometheus_remote_storage_metadata_failed_total
+        - prometheus_remote_storage_metadata_retried_total
+        - prometheus_remote_storage_metadata_total
+        - prometheus_remote_storage_samples_dropped_total
+        - prometheus_remote_storage_samples_failed_total
+        - prometheus_remote_storage_samples_in_total
+        - prometheus_remote_storage_samples_total
+        - prometheus_remote_storage_shard_capacity
+        - prometheus_remote_storage_shards
+        - prometheus_remote_storage_shards_desired
+        - prometheus_remote_storage_shards_max
+        - prometheus_remote_storage_shards_min
+        - prometheus_remote_storage_string_interner_zero_reference_releases_total
+        - prometheus_sd_azure_cache_hit_total
+        - prometheus_sd_azure_failures_total
+        - prometheus_sd_discovered_targets
+        - prometheus_sd_dns_lookup_failures_total
+        - prometheus_sd_failed_configs
+        - prometheus_sd_file_read_errors_total
+        - prometheus_sd_file_scan_duration_seconds
+        - prometheus_sd_file_watcher_errors_total
+        - prometheus_sd_http_failures_total
+        - prometheus_sd_kubernetes_events_total
+        - prometheus_sd_kubernetes_http_request_duration_seconds
+        - prometheus_sd_kubernetes_http_request_total
+        - prometheus_sd_kubernetes_workqueue_depth
+        - prometheus_sd_kubernetes_workqueue_items_total
+        - prometheus_sd_kubernetes_workqueue_latency_seconds
+        - prometheus_sd_kubernetes_workqueue_longest_running_processor_seconds
+        - prometheus_sd_kubernetes_workqueue_unfinished_work_seconds
+        - prometheus_sd_kubernetes_workqueue_work_duration_seconds
+        - prometheus_sd_received_updates_total
+        - prometheus_sd_updates_delayed_total
+        - prometheus_sd_updates_total
+        - prometheus_target_scrape_pool_reloads_failed_total
+        - prometheus_target_scrape_pool_reloads_total
+        - prometheus_target_scrape_pool_sync_total
+        - prometheus_target_scrape_pools_failed_total
+        - prometheus_target_scrape_pools_total
+        - prometheus_target_sync_failed_total
+        - prometheus_target_sync_length_seconds
+        - promhttp_metric_handler_requests_in_flight
+        - promhttp_metric_handler_requests_total
+        - remote_write_db_failures_total
+        - remote_write_failures_total
+        - remote_write_payload_size_bytes
+        - remote_write_records_processed_total
+        - remote_write_response_codes_total
+        - remote_write_timeseries_total
+        - storage_write_failure_total
+      prefix: []
+      suffix: []
+      contains: []
+      regex: []
+      additionalExact: []
+      additionalPrefix: []
+      additionalSuffix: []
+      additionalContains: []
+      additionalRegex: []
+    labels:
+      exact: []
+      prefix: []
+      suffix: []
+      contains: []
+      regex: []
+      additionalExact: []
+      additionalPrefix: []
+      additionalSuffix: []
+      additionalContains: []
+      additionalRegex: []
+
 prometheusConfig:
   configMapNameOverride: ''
   configMapAnnotations: {}

--- a/charts/cloudzero-agent/values.yaml
+++ b/charts/cloudzero-agent/values.yaml
@@ -403,6 +403,13 @@ aggregator:
     repository: ghcr.io/cloudzero/cloudzero-insights-controller/cloudzero-insights-controller
     tag: latest
     pullPolicy: IfNotPresent
+  cloudzero:
+    sendInterval: 1m
+    sendTimeout: 10s
+    rotateInterval: 30m
+  database:
+    maxRecords: 1500000
+    compressionLevel: 8
   collector:
     port: 8080
     resources:


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [CloudZero Code of Conduct](https://github.com/cloudzero/template-cloudzero-open-source/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/cloudzero/template-cloudzero-open-source/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

This adds a job to scrape metrics from the collector, and adds a lot of configuration for splitting out cost metrics from observability metrics. It was also designed to allow us to completely drop metrics and/or labels we're not interested in.

In order for the collector to know what to do with the metrics, the Gator accepts several lists of filters in its configuration. Those lists are configured in this chart.

There are basically 4 lists of metrics: cost, observability, cost labels, and observability labels. The cost and observability ones operate on the metric name, and if they match the metric is sent to the relevant list. If neither match, the metric is dropped. Similarly, each labels filter list is applied to the labels, and labels which don't match are dropped. Currently, for observability labels we do not have any filters, which means we will keep all of the labels. However, for cost metrics we do have filters and only those which match will be kept.

### References

> Include any links supporting this change such as a:
>
> - GitHub Issue/PR number addressed or fixed
> - StackOverflow post
> - Support forum thread
> - Related pull requests/issues from other repos
>
> If there are no references, simply delete this section.

### Testing

Testing is kind of annoying, but fairly straightforward: deploy it and wait for some metrics to come in, and check that they get sorted into the right location. Cost metrics will go into `cost_*_*.json.br`, and observability into `observability_*_*.json.br`. You'll probably want to lower `aggregator.database.maxRecords` in order to speed up testing.

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`