### PR TITLE
CP-26977: update nodeSelector settings for values, init jobs

### DIFF
--- a/charts/cloudzero-agent/templates/_helpers.tpl
+++ b/charts/cloudzero-agent/templates/_helpers.tpl
@@ -417,6 +417,7 @@ annotations:
 {{- end -}}
 {{- end -}}
 
+
 {{/*
 Name for the certificate init job resource. Should be a new name each installation/upgrade.
 */}}

--- a/charts/cloudzero-agent/templates/_helpers.tpl
+++ b/charts/cloudzero-agent/templates/_helpers.tpl
@@ -417,7 +417,6 @@ annotations:
 {{- end -}}
 {{- end -}}
 
-
 {{/*
 Name for the certificate init job resource. Should be a new name each installation/upgrade.
 */}}

--- a/charts/cloudzero-agent/templates/init-job.yaml
+++ b/charts/cloudzero-agent/templates/init-job.yaml
@@ -97,6 +97,18 @@ spec:
       labels:
         {{- include "cloudzero-agent.insightsController.initCertJob.matchLabels" . | nindent 8 }}
     spec:
+      {{- with (.Values.initCertJob.nodeSelector | default .Values.insightsController.server.nodeSelector) }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with (.Values.initCertJob.affinity | default .Values.insightsController.server.affinity) }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with (.Values.initCertJob.tolerations | default .Values.insightsController.server.tolerations) }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ include "cloudzero-agent.initCertJob.serviceAccountName" . }}
       restartPolicy: Never
       {{- include  "cloudzero-agent.initCertJob.imagePullSecrets" . | nindent 6 }}
@@ -190,16 +202,5 @@ spec:
               echo "The useCertManager flag is set to true. Skipping certificate generation and patching of resources."
               {{- end }}
               exit 0
-      {{- with (.Values.initCertJob.nodeSelector | default .Values.insightsController.server.nodeSelector) }}
-      nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with (.Values.initCertJob.affinity | default .Values.insightsController.server.affinity) }}
-      affinity:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with (.Values.initCertJob.tolerations | default .Values.insightsController.server.tolerations) }}
-      tolerations:
-        {{- toYaml . | nindent 8 }}
 {{- end }}
 {{- end }}

--- a/charts/cloudzero-agent/templates/init-job.yaml
+++ b/charts/cloudzero-agent/templates/init-job.yaml
@@ -66,15 +66,15 @@ spec:
           {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- end }}
-      {{- with .Values.insightsController.server.nodeSelector }}
+      {{- with (.Values.initBackfillJob.nodeSelector | default .Values.insightsController.server.nodeSelector) }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.insightsController.server.affinity }}
+      {{- with (.Values.initBackfillJob.affinity | default .Values.insightsController.server.affinity) }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.insightsController.server.tolerations }}
+      {{- with (.Values.initBackfillJob.tolerations | default .Values.insightsController.server.tolerations) }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -190,5 +190,16 @@ spec:
               echo "The useCertManager flag is set to true. Skipping certificate generation and patching of resources."
               {{- end }}
               exit 0
+      {{- with (.Values.initCertJob.nodeSelector | default .Values.insightsController.server.nodeSelector) }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with (.Values.initCertJob.affinity | default .Values.insightsController.server.affinity) }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with (.Values.initCertJob.tolerations | default .Values.insightsController.server.tolerations) }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
 {{- end }}
 {{- end }}

--- a/charts/cloudzero-agent/values.yaml
+++ b/charts/cloudzero-agent/values.yaml
@@ -334,12 +334,12 @@ insightsController:
       timeoutSeconds: 3
       successThreshold: 1
       failureThreshold: 5
+    nodeSelector: {}
+    tolerations: []
+    affinity: {}
   volumeMounts: []
   volumes: []
   resources: {}
-  nodeSelector: {}
-  tolerations: []
-  affinity: {}
   podAnnotations: {}
   podLabels: {}
   service:


### PR DESCRIPTION
### Description

- nodeSelector is now available for the `initCertJob`
- nodeSelector for `initBackfillJob` can now be set in the `initBackfillJob` section, defaults to previous value of `insightsController.server.nodeSelector`
- nodeSelector, tolerations, and affinity settings correctly moved to `insightsController.server` section of values.yaml

### Testing
**Given the following**
```yaml
initBackfillJob:
  nodeSelector:
    backfill-schedule: "true"
initCertJob:
  nodeSelector:
    cert-schedule: "true"
insightsController:
  server:
    nodeSelector:
      server-schedule: "true"
```

asserted that pods scheduled to nodes:
backfill -> ip-192-168-97-176.ec2.internal (labeled with  backfill-schedule: "true")
cert -> ip-192-168-91-87.ec2.internal         (labeled with  cert-schedule: "true")
server -> ip-192-168-116-243.ec2.internal (labeled with  server-schedule: "true")

**Given the following**
```yaml
initBackfillJob:
  nodeSelector: {}
initCertJob:
  nodeSelector: {}
insightsController:
  server:
    nodeSelector:
      server-schedule: "true"
```

asserted that all pods scheduled to `ip-192-168-116-243.ec2.internal`


- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced pod scheduling configuration with a fallback mechanism, enabling users to specify customized scheduling preferences that seamlessly default when not explicitly provided.
  - Consolidated scheduling settings into a unified section, offering a more intuitive and flexible approach to managing pod placement options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->