### PR TITLE
CP-27043: derive scrape job relabel filter from gator filters

### DIFF
--- a/charts/cloudzero-agent/templates/_helpers.tpl
+++ b/charts/cloudzero-agent/templates/_helpers.tpl
@@ -191,6 +191,69 @@ Combine metric lists
 {{- end -}}
 
 {{/*
+Internal helper function for generating a metric filter regex
+*/}}
+{{- define "cloudzero-agent.generateMetricFilterRegexInternal" -}}
+{{- $patterns := list -}}
+{{/* Handle exact matches */}}
+{{- $exactPatterns := uniq .exact -}}
+{{- if gt (len $exactPatterns) 0 -}}
+{{- $exactPattern := printf "^(%s)$" (join "|" $exactPatterns) -}}
+{{- $patterns = append $patterns $exactPattern -}}
+{{- end -}}
+
+{{/* Handle prefix matches */}}
+{{- $prefixPatterns := uniq .prefix -}}
+{{- if gt (len $prefixPatterns) 0 -}}
+{{- $prefixPattern := printf "^(%s)" (join "|" $prefixPatterns) -}}
+{{- $patterns = append $patterns $prefixPattern -}}
+{{- end -}}
+
+{{/* Handle suffix matches */}}
+{{- $suffixPatterns := uniq .suffix -}}
+{{- if gt (len $suffixPatterns) 0 -}}
+{{- $suffixPattern := printf "(%s)$" (join "|" $suffixPatterns) -}}
+{{- $patterns = append $patterns $suffixPattern -}}
+{{- end -}}
+
+{{/* Handle contains matches */}}
+{{- $containsPatterns := uniq .contains -}}
+{{- if gt (len $containsPatterns) 0 -}}
+{{- $containsPattern := printf "(%s)" (join "|" $containsPatterns) -}}
+{{- $patterns = append $patterns $containsPattern -}}
+{{- end -}}
+
+{{/* Handle regex matches */}}
+{{- $regexPatterns := uniq .regex -}}
+{{- if gt (len $regexPatterns) 0 -}}
+{{- $regexPattern := printf "(%s)" (join "|" $regexPatterns) -}}
+{{- $patterns = append $patterns $regexPattern -}}
+{{- end -}}
+
+{{- join "|" $patterns -}}
+{{- end -}}
+
+{{- define "cloudzero-agent.generateMetricNameFilterRegex" -}}
+{{- include "cloudzero-agent.generateMetricFilterRegexInternal" (dict
+  "exact"    (uniq (concat .metricFilters.cost.name.exact    .metricFilters.observability.name.exact    .metricFilters.cost.name.additionalExact    .metricFilters.observability.name.additionalExact))
+  "prefix"   (uniq (concat .metricFilters.cost.name.prefix   .metricFilters.observability.name.prefix   .metricFilters.cost.name.additionalPrefix   .metricFilters.observability.name.additionalPrefix))
+  "suffix"   (uniq (concat .metricFilters.cost.name.suffix   .metricFilters.observability.name.suffix   .metricFilters.cost.name.additionalSuffix   .metricFilters.observability.name.additionalSuffix))
+  "contains" (uniq (concat .metricFilters.cost.name.contains .metricFilters.observability.name.contains .metricFilters.cost.name.additionalContains .metricFilters.observability.name.additionalContains))
+  "regex"    (uniq (concat .metricFilters.cost.name.regex    .metricFilters.observability.name.regex    .metricFilters.cost.name.additionalRegex    .metricFilters.observability.name.additionalRegex))
+) -}}
+{{- end -}}
+
+{{- define "cloudzero-agent.generateMetricLabelFilterRegex" -}}
+{{- include "cloudzero-agent.generateMetricFilterRegexInternal" (dict
+  "exact"    (uniq (concat .metricFilters.cost.labels.exact    .metricFilters.observability.labels.exact    .metricFilters.cost.labels.additionalExact    .metricFilters.observability.labels.additionalExact))
+  "prefix"   (uniq (concat .metricFilters.cost.labels.prefix   .metricFilters.observability.labels.prefix   .metricFilters.cost.labels.additionalPrefix   .metricFilters.observability.labels.additionalPrefix))
+  "suffix"   (uniq (concat .metricFilters.cost.labels.suffix   .metricFilters.observability.labels.suffix   .metricFilters.cost.labels.additionalSuffix   .metricFilters.observability.labels.additionalSuffix))
+  "contains" (uniq (concat .metricFilters.cost.labels.contains .metricFilters.observability.labels.contains .metricFilters.cost.labels.additionalContains .metricFilters.observability.labels.additionalContains))
+  "regex"    (uniq (concat .metricFilters.cost.labels.regex    .metricFilters.observability.labels.regex    .metricFilters.cost.labels.additionalRegex    .metricFilters.observability.labels.additionalRegex))
+) -}}
+{{- end -}}
+
+{{/*
 Generate metric filters
 */}}
 {{- define "cloudzero-agent.generateMetricFilters" -}}

--- a/charts/cloudzero-agent/templates/cm.yaml
+++ b/charts/cloudzero-agent/templates/cm.yaml
@@ -151,7 +151,7 @@ data:
         metrics_path: /metrics
         metric_relabel_configs:
           - source_labels: [__name__]
-            regex: "^({{ join "|" .Values.aggregatorMetrics }})$"
+            regex: "{{ include "cloudzero-agent.generateMetricNameFilterRegex" .Values }}"
             action: keep
       {{- end }}
       {{- if .Values.prometheusConfig.scrapeJobs.prometheus.enabled }}

--- a/charts/cloudzero-agent/values.yaml
+++ b/charts/cloudzero-agent/values.yaml
@@ -117,32 +117,6 @@ prometheusMetrics:
   - prometheus_target_scrape_pools_total
   - prometheus_target_sync_failed_total
   - prometheus_target_sync_length_seconds
-aggregatorMetrics:
-  - go_gc_duration_seconds
-  - go_gc_duration_seconds_count
-  - go_gc_duration_seconds_sum
-  - go_gc_gogc_percent
-  - go_gc_gomemlimit_bytes
-  - go_goroutines
-  - go_memstats_alloc_bytes
-  - go_memstats_heap_alloc_bytes
-  - go_memstats_heap_idle_bytes
-  - go_memstats_heap_inuse_bytes
-  - go_memstats_heap_objects
-  - go_memstats_last_gc_time_seconds
-  - go_memstats_alloc_bytes
-  - go_memstats_stack_inuse_bytes
-  - go_threads
-  - http_request_duration_seconds_bucket
-  - http_request_duration_seconds_count
-  - http_request_duration_seconds_sum
-  - http_requests_total
-  - prometheus_remote_storage_exemplars_in_total
-  - prometheus_remote_storage_histograms_in_total
-  - prometheus_remote_storage_samples_in_total
-  - prometheus_remote_storage_string_interner_zero_reference_releases_total
-  - promhttp_metric_handler_requests_in_flight
-  - promhttp_metric_handler_requests_total
 # -- Any items added to this array will be added to the metrics that are sent to CloudZero, in addition to the minimal labels that CloudZero requires.
 additionalMetricLabels: []
 

--- a/charts/cloudzero-agent/values.yaml
+++ b/charts/cloudzero-agent/values.yaml
@@ -326,7 +326,8 @@ metricFilters:
         - shipper_disk_cleanup_failure_total
         - shipper_disk_cleanup_success_total
         - shipper_disk_cleanup_percentage
-      prefix: []
+      prefix:
+        - czo_
       suffix: []
       contains: []
       regex: []


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [CloudZero Code of Conduct](https://github.com/cloudzero/template-cloudzero-open-source/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/cloudzero/template-cloudzero-open-source/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

This uses the `metricFilters` fields to generate a regex for the gator scrape job instead of relying on the separate `aggregatorMetrics`, which I have removed. This removes a maintenance burden which was already getting out of sync, and allows the user to add filters which will be applied to the scrape job as well as the filtering mechanism on the collector container.

I also dropped in a quick filter to assume anything prefixed with "czo_" is an observability metric we want to keep. This won't really do anything until we update the gator to use those prefixes, but once we do that should eliminate another maintenance burden.

### References

> Include any links supporting this change such as a:
>
> - GitHub Issue/PR number addressed or fixed
> - StackOverflow post
> - Support forum thread
> - Related pull requests/issues from other repos
>
> If there are no references, simply delete this section.

### Testing

Just deploy it, then take a look at the metrics that make it past the filter.

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a dynamic, regex-based mechanism for filtering metrics, enhancing how cost and observability metrics are identified.

- **Chores**
  - Removed the previously collected metrics related to garbage collection and HTTP request durations.
  - Updated cost metric filtering to consistently apply a "czo_" prefix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->