### PR TITLE
CP-27062: don't delete jobs after they have finished

### DIFF
--- a/charts/cloudzero-agent/docs/upgrades.md
+++ b/charts/cloudzero-agent/docs/upgrades.md
@@ -44,12 +44,8 @@ See the ArgoCD [Hook Deletion](https://argo-cd.readthedocs.io/en/stable/user-gui
 ```sh
 Error: UPGRADE FAILED: failed to replace object: Job.batch "cloudzero-agent-backfill"
 ```
-**Solution:**  
-1. **Wait for the `backfill` Job to complete**  
-   - The Job will be **automatically deleted after 180 seconds** (`ttlSecondsAfterFinished`).
-   - Once the Job is removed, retry the Helm upgrade.
-
-2. **Manually delete the running Jobs and retry the upgrade**  
+**Solution:**
+1. **Manually delete the running Jobs and retry the upgrade**
    ```sh
    kubectl delete job -n <NAMESPACE> -l app.kubernetes.io/component=webhook-server
    helm upgrade --install <RELEASE_NAME> cloudzero/cloudzero-agent -n <NAMESPACE> --version <version> --force
@@ -58,8 +54,6 @@ Error: UPGRADE FAILED: failed to replace object: Job.batch "cloudzero-agent-back
 
 ---
 ## **Implementation Notes**
-1. **`backfill` Job Cleanup:** The Job includes a `ttlSecondsAfterFinished: 180` to automatically remove itself.
-2. **`init-cert` Job Cleanup:** Uses `ttlSecondsAfterFinished: 180` for cleanup.
-3. **Deployment Rollout:** The `init-cert` Job includes a mechanism to force a Deployment restart when it completes.
+1. **Deployment Rollout:** The `init-cert` Job includes a mechanism to force a Deployment restart when it completes.
 
 

--- a/charts/cloudzero-agent/templates/_helpers.tpl
+++ b/charts/cloudzero-agent/templates/_helpers.tpl
@@ -514,12 +514,17 @@ Map for initBackfillJob values; this allows us to preferably use initBackfillJob
 {{- end }}
 
 {{/*
+Name for a job resource
+*/}}
+{{- define "cloudzero-agent.jobName" -}}
+{{- printf "%s-%s-%s" .Release .Name (. | toYaml | sha256sum) | trunc 61 -}}
+{{- end }}
+
+{{/*
 Name for the backfill job resource
 */}}
 {{- define "cloudzero-agent.initBackfillJobName" -}}
-{{- $name := printf "%s-backfill-%s" .Release.Name .Chart.Version }}
-{{- $imageRef := splitList ":" (include  "cloudzero-agent.initBackfillJob.imageReference" .) | last }}
-{{- printf "%s-%s" $name ($imageRef | trunc 6) | trunc 61 | replace "." "-" | trimSuffix "-" -}}
+{{- include "cloudzero-agent.jobName" (dict "Release" .Release.Name "Name" "backfill" "Version" .Chart.Version "Values" .Values) -}}
 {{- end }}
 
 {{/*
@@ -536,9 +541,7 @@ annotations:
 Name for the certificate init job resource. Should be a new name each installation/upgrade.
 */}}
 {{- define "cloudzero-agent.initCertJobName" -}}
-{{ $version := .Chart.Version | replace "." "-" }}
-{{- $name := (printf "%s-init-cert-%s" (include "cloudzero-agent.insightsController.server.webhookFullname" .) $version | trunc 60) -}}
-{{- $name -}}-{{ .Release.Revision }}
+{{- include "cloudzero-agent.jobName" (dict "Release" .Release.Name "Name" "init-cert" "Version" .Chart.Version "Values" .Values) -}}
 {{- end }}
 
 {{/*

--- a/charts/cloudzero-agent/templates/init-job.yaml
+++ b/charts/cloudzero-agent/templates/init-job.yaml
@@ -10,7 +10,6 @@ metadata:
   labels:
     {{- include "cloudzero-agent.insightsController.labels" . | nindent 4 }}
 spec:
-  ttlSecondsAfterFinished: {{ $backFillValues.ttlSecondsAfterFinished }}
   template:
     metadata:
       name: {{ include "cloudzero-agent.initBackfillJobName" . }}
@@ -90,7 +89,6 @@ metadata:
   labels:
     {{- include "cloudzero-agent.insightsController.labels" . | nindent 4 }}
 spec:
-  ttlSecondsAfterFinished: {{ .Values.initCertJob.ttlSecondsAfterFinished }}
   template:
     metadata:
       name: {{ include "cloudzero-agent.initCertJobName" . }}

--- a/charts/cloudzero-agent/values.yaml
+++ b/charts/cloudzero-agent/values.yaml
@@ -369,7 +369,6 @@ initBackfillJob:
   #   tag: 0.1.1
   #   pullPolicy: Always
   enabled: true
-  ttlSecondsAfterFinished: 180
 
 # -- This is a deprecated field that is replaced by initBackfillJob. However, the fields are identical, and initScrapeJob can still be used to configure the backFill/scrape Job.
 # initScrapeJob:
@@ -394,7 +393,6 @@ initCertJob:
     serviceAccountName: ""
     clusterRoleName: ""
     clusterRoleBindingName: ""
-  ttlSecondsAfterFinished: 5
 
 kubeStateMetrics:
   enabled: true


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [CloudZero Code of Conduct](https://github.com/cloudzero/template-cloudzero-open-source/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/cloudzero/template-cloudzero-open-source/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

Some tools for managing Kubernetes, notably Flux, don't play nicely with jobs that automatically clean themselves up by setting a `ttlSecondsAfterFinished`; they see that the job has been deleted, and recreate the job.  This results in an endless cycle of the job being run then deleting itself over and over, when we really only want it to be run once.

The reason we were using `ttlSecondsAfterFinished` was because we *do* want the job to run when upgrading the chart.  This change gives us that benefit without relying on `ttlSecondsAfetrFinished`.

Specifically, we now append a (partial) SHA-256 checksum of the chart version and the configuration values in the job name. This means that, from Kubernetes' perspective, whenever a chart is upgraded (even if it is just a configuration change), a completely new job is created and the old one is destroyed.

### References

> Include any links supporting this change such as a:
>
> - GitHub Issue/PR number addressed or fixed
> - StackOverflow post
> - Support forum thread
> - Related pull requests/issues from other repos
>
> If there are no references, simply delete this section.

### Testing

> Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
>
> Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.
>
> Also include details of the environment this PR was developed in (language/platform/browser version).

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`