### PR TITLE
CP-27613: add action to ensure agent chart isn't changed here

### DIFF
--- a/.github/workflows/dont-change-agent-chart.yml
+++ b/.github/workflows/dont-change-agent-chart.yml
@@ -1,0 +1,27 @@
+name: Ensure no changes to Agent chart
+on:
+  push:
+    branches-ignore:
+    - develop
+
+jobs:
+  check-for-agent-chart-changes:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Dump GitHub context
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: |
+          echo "$GITHUB_CONTEXT"
+
+      - name: Check for agent chart changes
+        run: |
+          if git diff --name-only origin/${{ github.event.repository.default_branch }} | grep -qE '^charts/cloudzero-agent'; then
+            echo "Changes to chart/cloudzero-agent must be made in the helm/ directory of cloudzero/cloudzero-agent-validator; they will be mirrored to this repository."
+            exit 1
+          fi


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [CloudZero Code of Conduct](https://github.com/cloudzero/template-cloudzero-open-source/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/cloudzero/template-cloudzero-open-source/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

This just adds a quick status check which will fail if your commit touches anything in the charts/cloudzero-agent directory when committing to any branch other than develop, which is excluded so commits mirrored from charts/cloudzero-agent-validator don't cause the check to fail.

### References

> Include any links supporting this change such as a:
>
> - GitHub Issue/PR number addressed or fixed
> - StackOverflow post
> - Support forum thread
> - Related pull requests/issues from other repos
>
> If there are no references, simply delete this section.

### Testing

> Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
>
> Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.
>
> Also include details of the environment this PR was developed in (language/platform/browser version).

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`