### PR TITLE
CP-28969: only run dont-change-agent-chart action on PRs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,7 @@
 By submitting a PR to this repository, you agree to the terms within the [CloudZero Code of Conduct](https://github.com/cloudzero/template-cloudzero-open-source/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/cloudzero/template-cloudzero-open-source/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.
 
+Please note that changes to the `cloudzero-agent` Helm chart should be made instead in the [`helm directory`](https://github.com/Cloudzero/cloudzero-agent/tree/develop/helm) in the [cloudzero-agent repository](https://github.com/Cloudzero/cloudzero-agent/), and will automatically be mirrored to this repository as soon as they are merged.
+
 ### Description
 
 > Describe the purpose of this PR along with any background information and the impacts of the proposed change. For the benefit of the community, please do not assume prior context.

--- a/.github/workflows/dont-change-agent-chart.yml
+++ b/.github/workflows/dont-change-agent-chart.yml
@@ -1,8 +1,6 @@
 name: Ensure no changes to Agent chart
 on:
-  push:
-    branches-ignore:
-    - develop
+  pull_request:
 
 jobs:
   check-for-agent-chart-changes:


### PR DESCRIPTION
### Description

We use PRs for everything in this repo, *except* for changes being mirrored to this repo from the agent repo, which is the one thing we don't really want to check. Triggering this workflow only on PRs should give us the desired behavior in a much cleaner way than trying to condition it on the branch name, especially since GitHub likes to set the branch name to the target of the PR...

By submitting a PR to this repository, you agree to the terms within the [CloudZero Code of Conduct](https://github.com/cloudzero/template-cloudzero-open-source/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/cloudzero/template-cloudzero-open-source/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### References

> Include any links supporting this change such as a:
>
> - GitHub Issue/PR number addressed or fixed
> - StackOverflow post
> - Support forum thread
> - Related pull requests/issues from other repos
>
> If there are no references, simply delete this section.

### Testing

> Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
>
> Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.
>
> Also include details of the environment this PR was developed in (language/platform/browser version).

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`