### PR TITLE
Fix issue where argocd would have a perma-diff

### DIFF
--- a/charts/cloudzero-agent/templates/webhook-certificate.yaml
+++ b/charts/cloudzero-agent/templates/webhook-certificate.yaml
@@ -16,8 +16,10 @@ spec:
     algorithm: RSA
     encoding: PKCS1
     size: 2048
-  duration: 2160h0m0s # 90d
-  renewBefore: 360h0m0s # 15d
+  # Because sometimes this will get rendered as `2160h` it will cause a permadiff with ArgoCD when the chart says `2160h0m0s`
+  # Explicitly force it to be rendered as a non-truncatable value
+  duration: 2159h59m59s # 90d
+  renewBefore: 359h59m59s # 15d
   dnsNames:
     - {{ include "cloudzero-agent.serviceName" . }}.{{ .Release.Namespace }}.svc
   issuerRef:


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [CloudZero Code of Conduct](https://github.com/cloudzero/template-cloudzero-open-source/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/cloudzero/template-cloudzero-open-source/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

Please note that changes to the `cloudzero-agent` Helm chart should be made instead in the [`helm directory`](https://github.com/Cloudzero/cloudzero-agent/tree/develop/helm) in the [cloudzero-agent repository](https://github.com/Cloudzero/cloudzero-agent/), and will automatically be mirrored to this repository as soon as they are merged.

### Description

The k8s API server will sometimes truncate `360h0m0s` into `360h`. This breaks ArgoCD because it does a text diff and can't reconcile the change. 

This change forces a time period which cannot be abbreviated or converted. This will ensure that diff don't generate spurious changes.


### Testing

No testing, as it's a config value change by 1s.

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`