### PR TITLE
CP-29708: pin softprops/action-gh-release to v2.2.2

### DIFF
--- a/.github/workflows/build-and-publish-beta-chart.yml
+++ b/.github/workflows/build-and-publish-beta-chart.yml
@@ -127,7 +127,7 @@ jobs:
 
       # Step 5: Create GitHub Release
       - name: Create Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v2.2.2
         with:
           name: ${{ env.NEW_VERSION }}
           tag_name: ${{ env.NEW_VERSION }}

--- a/.github/workflows/build-and-publish-chart.yml
+++ b/.github/workflows/build-and-publish-chart.yml
@@ -142,7 +142,7 @@ jobs:
 
       # Step 8: Create GitHub Release
       - name: Create Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v2.2.2
         with:
           name: ${{ env.NEW_VERSION }}
           tag_name: ${{ env.NEW_VERSION }}


### PR DESCRIPTION
This works around a bug in v2.3.0, which seems to be broken.  See https://github.com/softprops/action-gh-release/issues/628 for details.