### PR TITLE
chore: Adds the missing properties(defaults.tag and defaults.reposito…

### DIFF
--- a/charts/cloudzero-agent/values.schema.json
+++ b/charts/cloudzero-agent/values.schema.json
@@ -5831,6 +5831,12 @@
         "image": {
           "$ref": "#/$defs/com.cloudzero.agent.image"
         },
+        "repository":{
+          "type": ["string", "null"]
+        },
+        "tag":{
+          "type": ["string", "null"]
+        },
         "labels": {
           "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/labels"
         },


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [CloudZero Code of Conduct](https://github.com/cloudzero/template-cloudzero-open-source/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/cloudzero/template-cloudzero-open-source/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

Please note that changes to the `cloudzero-agent` Helm chart should be made instead in the [`helm directory`](https://github.com/Cloudzero/cloudzero-agent/tree/develop/helm) in the [cloudzero-agent repository](https://github.com/Cloudzero/cloudzero-agent/), and will automatically be mirrored to this repository as soon as they are merged.

### Description

On PicPay, we need to push the provider's container images to our private repository. This approach helps us conduct security scans and reduces costs associated with data transfer.

After embedding the image, I needed to point the tag and repository to our private repository. I noticed that we can apply this change by updating the values in the defaults property.

Here’s the relevant link for reference: [Cloudzero Helm Chart](https://github.com/Cloudzero/cloudzero-charts/blob/develop/charts/cloudzero-agent/templates/_helpers.tpl#L785).

After setting those values, I started encountering a schema error during the templating step. To resolve this, I created a PR to add the missing properties to the schema definition.


### References

> Include any links supporting this change such as a:
>
> - GitHub Issue/PR number addressed or fixed
> - StackOverflow post
> - Support forum thread
> - Related pull requests/issues from other repos
>
> If there are no references, simply delete this section.

### Testing

Inside cloudzero-agent chart run the helm template command -> 
```sh
helm template test . --set existingSecretName="test-123" --set defaults.tag="test" --set defaults.repository="a"  --dry-run --debug
```
Output
```sh
Error: values don't meet the specifications of the schema(s) in the following chart(s):
cloudzero-agent:
- at '/defaults': additional properties 'tag', 'repository' not allowed

helm.go:92: 2025-10-27 14:46:03.140248 -0300 -03 m=+0.093139453 [debug] values don't meet the specifications of the schema(s) in the following chart(s):
cloudzero-agent:
- at '/defaults': additional properties 'tag', 'repository' not allowed
```
### Checklist

- [ ] I have added documentation for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`